### PR TITLE
(improvement):  add logic to return proper word test or tests

### DIFF
--- a/comment.js
+++ b/comment.js
@@ -10,7 +10,7 @@ class Comment {
     if (diff.added.length || diff.missing.length) {
       
       if (diff.added.length) {
-        this.body += `\n#### ✔️ Added ${diff.added.length} tests\n`;
+        this.body += `\n#### ✔️ Added ${diff.added.length} test(s)\n`;
 
         if (diff.added.length < 300) { // 300 tests at once? not a useful diff
           this.body += '\n\n```diff\n';
@@ -20,7 +20,7 @@ class Comment {
       }
 
       if (diff.missing.length) {
-        this.body += `\n#### 🗑️ Removed ${diff.missing.length} tests\n`;
+        this.body += `\n#### 🗑️ Removed ${diff.missing.length} test(s)\n`;
 
         if (diff.added.length < 300) {
           this.body += '\n\n```diff\n';
@@ -37,14 +37,14 @@ class Comment {
   writeSkippedDiff(diff) {
     
     if (diff.added.length) {
-      this.body += `\n\n#### ⚠️ Skipped ${diff.added.length} tests\n`;
+      this.body += `\n\n#### ⚠️ Skipped ${diff.added.length} test(s)\n`;
       this.body += '```diff\n'
       diff.added.forEach(test => this.body +=`\n- ${Object.values(test)[0]}`);        
       this.body += '\n```\n\n'
     }
 
     if (diff.missing.length) {
-      this.body += `\n\n#### ♻ Restored ${diff.missing.length} tests\n`;
+      this.body += `\n\n#### ♻ Restored ${diff.missing.length} test(s)\n`;
       this.body += '```diff\n';
       diff.missing.forEach(test => this.body += `\n+ ${Object.values(test)[0]}`);        
       this.body += '\n```\n\n';
@@ -58,7 +58,7 @@ class Comment {
 
     this.body += 
 `\n\n<details>
-  <summary>⚠️ List all skipped tests (${list.length})</summary>
+  <summary>⚠️ List all skipped test(s) (${list.length})</summary>
 
 ${body}
 

--- a/comment.js
+++ b/comment.js
@@ -10,7 +10,7 @@ class Comment {
     if (diff.added.length || diff.missing.length) {
       
       if (diff.added.length) {
-        this.body += `\n#### ✔️ Added ${diff.added.length} test(s)\n`;
+        this.body += `\n#### ✔️ Added ${diff.added.length} ${properWordForNumberOfTests(diff.added.length)}\n`;
 
         if (diff.added.length < 300) { // 300 tests at once? not a useful diff
           this.body += '\n\n```diff\n';
@@ -20,7 +20,7 @@ class Comment {
       }
 
       if (diff.missing.length) {
-        this.body += `\n#### 🗑️ Removed ${diff.missing.length} test(s)\n`;
+        this.body += `\n#### 🗑️ Removed ${diff.missing.length} ${properWordForNumberOfTests(diff.missing.length)}\n`;
 
         if (diff.added.length < 300) {
           this.body += '\n\n```diff\n';
@@ -37,14 +37,14 @@ class Comment {
   writeSkippedDiff(diff) {
     
     if (diff.added.length) {
-      this.body += `\n\n#### ⚠️ Skipped ${diff.added.length} test(s)\n`;
+      this.body += `\n\n#### ⚠️ Skipped ${diff.added.length} ${properWordForNumberOfTests(diff.added.length)}\n`;
       this.body += '```diff\n'
       diff.added.forEach(test => this.body +=`\n- ${Object.values(test)[0]}`);        
       this.body += '\n```\n\n'
     }
 
     if (diff.missing.length) {
-      this.body += `\n\n#### ♻ Restored ${diff.missing.length} test(s)\n`;
+      this.body += `\n\n#### ♻ Restored ${diff.missing.length} ${properWordForNumberOfTests(diff.missing.length)}\n`;
       this.body += '```diff\n';
       diff.missing.forEach(test => this.body += `\n+ ${Object.values(test)[0]}`);        
       this.body += '\n```\n\n';
@@ -58,7 +58,7 @@ class Comment {
 
     this.body += 
 `\n\n<details>
-  <summary>⚠️ List all skipped test(s) (${list.length})</summary>
+  <summary>⚠️ List all skipped ${properWordForNumberOfTests(list.length)} (${list.length})</summary>
 
 ${body}
 
@@ -125,6 +125,9 @@ class CommentError extends Error {
   }
 }
 
+function properWordForNumberOfTests(numberOfTests) {
+  return numberOfTests === 1 ? 'test' : 'tests';
+}
 
 module.exports = Comment;
 module.exports.Error = CommentError;


### PR DESCRIPTION
There is a case when there is only one test is affected. 

🌀 Tests overview by [Testomatio](https://testomat.io)


Found **947** mocha tests in 74 files 
#### ✔️ Added 1 test


```diff

+ screenshotOnFail: should create screenshot with unique name when uuid is null
```



<details>
  <summary>⚠️ List all skipped test (1)</summary>

* [~~should resize window to maximum screen dimensions~~](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/WebDriver_test.js#L786)

</details>



<details>
  <summary>📎 List all suites (62)</summary>


* **GraphQL (9 tests)** [test/graphql/GraphQL_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/graphql/GraphQL_test.js)
* **GraphQLDataFactory (6 tests)** [test/graphql/GraphQLDataFactory_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/graphql/GraphQLDataFactory_test.js)
* **Appium (73 tests)** [test/helper/Appium_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Appium_test.js)
* **Appium Web (16 tests)** [test/helper/AppiumWeb_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/AppiumWeb_test.js)
* **Nightmare (17 tests)** [test/helper/Nightmare_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Nightmare_test.js)
* **Playwright (79 tests)** [test/helper/Playwright_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Playwright_test.js)
* **#_startBrowser (2 tests)** [test/helper/Playwright_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Playwright_test.js)
* **Playwright - BasicAuth (1 tests)** [test/helper/Playwright_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Playwright_test.js)
* **Playwright - Emulation (1 tests)** [test/helper/Playwright_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Playwright_test.js)
* **Protractor (114 tests)** [test/helper/Protractor_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Protractor_test.js)
* **Protractor-NonAngular (47 tests)** [test/helper/ProtractorWeb_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/ProtractorWeb_test.js)
* **Puppeteer - BasicAuth (2 tests)** [test/helper/Puppeteer_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Puppeteer_test.js)
* **Puppeteer (96 tests)** [test/helper/Puppeteer_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Puppeteer_test.js)
* **Puppeteer (remote browser) (2 tests)** [test/helper/Puppeteer_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/Puppeteer_test.js)
* **TestCafe (5 tests)** [test/helper/TestCafe_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/TestCafe_test.js)
* **WebDriver (202 tests)** [test/helper/WebDriver_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/WebDriver_test.js)
* **WebDriver - Basic Authentication (1 tests)** [test/helper/WebDriver_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/WebDriver_test.js)
* **WebDriverIO (94 tests)** [test/helper/WebDriverIO_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/helper/WebDriverIO_test.js)
* **ApiDataFactory (10 tests)** [test/rest/ApiDataFactory_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/rest/ApiDataFactory_test.js)
* **REST (17 tests)** [test/rest/REST_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/rest/REST_test.js)
* **CodeceptJS Allure Plugin (4 tests)** [test/runner/allure_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/allure_test.js)
* **BDD Gherkin (16 tests)** [test/runner/bdd_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/bdd_test.js)
* **CodeceptJS Bootstrap and Teardown (18 tests)** [test/runner/bootstrap_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/bootstrap_test.js)
* **CodeceptJS Runner (24 tests)** [test/runner/codecept_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/codecept_test.js)
* **Codeceptjs Events (2 tests)** [test/runner/codecept_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/codecept_test.js)
* **CodeceptJS commentStep plugin (2 tests)** [test/runner/comment_step_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/comment_step_test.js)
* **Definitions (9 tests)** [test/runner/definitions_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/definitions_test.js)
* **dry-run command (11 tests)** [test/runner/dry_run_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/dry_run_test.js)
* **CodeceptJS Interface (16 tests)** [test/runner/interface_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/interface_test.js)
* **list commands (1 tests)** [test/runner/list_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/list_test.js)
* **CodeceptJS Interface (16 tests)** [test/runner/pageobject_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/pageobject_test.js)
* **CodeceptJS Multiple Runner (20 tests)** [test/runner/run_multiple_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/run_multiple_test.js)
* **run-rerun command (5 tests)** [test/runner/run_rerun_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/run_rerun_test.js)
* **CodeceptJS Workers Runner (8 tests)** [test/runner/run_workers_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/run_workers_test.js)
* **CodeceptJS session (3 tests)** [test/runner/session_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/session_test.js)
* **Todo (3 tests)** [test/runner/todo_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/todo_test.js)
* **Translation (1 tests)** [test/runner/translation_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/translation_test.js)
* **CodeceptJS within (3 tests)** [test/runner/within_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/runner/within_test.js)
* **Actor (6 tests)** [test/unit/actor_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/actor_test.js)
* **Assertion (2 tests)** [test/unit/assert_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/assert_test.js)
* **empty assertion (4 tests)** [test/unit/assert/empty_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/assert/empty_test.js)
* **equal assertion (8 tests)** [test/unit/assert/equal_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/assert/equal_test.js)
* **equal assertion (8 tests)** [test/unit/assert/include_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/assert/include_test.js)
* **BDD (28 tests)** [test/unit/bdd_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/bdd_test.js)
* **Config (4 tests)** [test/unit/config_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/config_test.js)
* **Container (20 tests)** [test/unit/container_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/container_test.js)
* **DataTableArgument (3 tests)** [test/unit/data/dataTableArgument_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/data/dataTableArgument_test.js)
* **DataTable (10 tests)** [test/unit/data/table_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/data/table_test.js)
* **ui (22 tests)** [test/unit/data/ui_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/data/ui_test.js)
* **ElementNotFound error (5 tests)** [test/unit/helper/element_not_found_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/helper/element_not_found_test.js)
* **FileSystem (4 tests)** [test/unit/helper/FileSystem_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/helper/FileSystem_test.js)
* **Locator (22 tests)** [test/unit/locator_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/locator_test.js)
* **Output (3 tests)** [test/unit/output_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/output_test.js)
* **parser (2 tests)** [test/unit/parser_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/parser_test.js)
* **customLocator (4 tests)** [test/unit/plugin/customLocator_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/plugin/customLocator_test.js)
* **retryFailedStep (6 tests)** [test/unit/plugin/retryFailedStep_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/plugin/retryFailedStep_test.js)
* **screenshotOnFail (4 tests)** [test/unit/plugin/screenshotOnFail_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/plugin/screenshotOnFail_test.js)
* **Recorder (7 tests)** [test/unit/recorder_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/recorder_test.js)
* **Scenario (5 tests)** [test/unit/scenario_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/scenario_test.js)
* **Step (6 tests)** [test/unit/steps_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/steps_test.js)
* **ui (22 tests)** [test/unit/ui_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/ui_test.js)
* **utils (22 tests)** [test/unit/utils_test.js](https://github.com/Codeception/CodeceptJS/tree/c6939110835b500d3564d60285fefea432465ab1/test/unit/utils_test.js)

</details>

