### PR TITLE
sync improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,36 @@ TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js"
 
 ```
 
+## Disable Detached Tests
+
+If a test from a previous import was not found on next import it is marked as "detached".
+This is done to ensure that deleted tests are not staying in Testomatio while deleted in codebase.
+
+To disable this behavior and don't mark anything on detached on import use `--no-detached` option
+
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --no-detached
+```
+
+## Synchronous Import
+
+By default `check-tests` doesn't wait for all tests to be proceesed. It sends request to Testomatio and exits. To wait for processing to finish use `--sync` option.
+
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --sync
+```
+Please note, that this will take a long time on a large codebase.
+
+## Auto-assign Test IDs in Source Code
+
+To disable guess matching for tests it is recommend to use Testomatio IDs to map a test in source code to a test in Testomatio. Testomatio IDs can be put automatically into the test names into source code when `--update-ids` option is used:
+
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --update-ids
+```
+
+Tests imported with `--update-ids` will be processed in synchronouse mode, so the script will finish after all tests are processed.
+
 ### Import Into a Specific Suite
 
 To put all imported tests into a specific suite (folder) pass in `TESTOMATIO_PREPEND_DIR` environment variable:
@@ -454,6 +484,12 @@ If you face issues parsing TypeScript file menitioning `@babel/core` or `@babel/
 
 ```
 npm i @babel/core @babel/plugin-transform-typescript --save-dev
+```
+
+Now tests TypeScript can be imported with `--typescript` option:
+
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --typescript
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -451,7 +451,7 @@ TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --no-de
 
 ## Synchronous Import
 
-By default `check-tests` doesn't wait for all tests to be proceesed. It sends request to Testomatio and exits. To wait for processing to finish use `--sync` option.
+By default `check-tests` doesn't wait for all tests to be processed. It sends request to Testomatio and exits. To wait for processing to finish use `--sync` option.
 
 ```
 TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --sync

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,9 +18,9 @@ function getStringValue(path) {
   }
   if (hasTemplateArgument(path)) {
     return getQuasiArgument(path)
-  }  
+  }
   return;
-} 
+}
 
 function hasTemplateArgument(path) {
   if (!path.arguments) return false;
@@ -83,7 +83,8 @@ function parseComments(source) {
   return comments;
 }
 
-async function updateFiles(testData, testomatioMap, workDir) {
+function updateFiles(testData, testomatioMap, workDir) {
+  const files = [];
   for (const testArr of testData) {
     const file = `${workDir}/${testArr[0].file}`;
     let fileContent = fs.readFileSync(file, {encoding:'utf8'})
@@ -96,19 +97,21 @@ async function updateFiles(testData, testomatioMap, workDir) {
         fileContent = fileContent.replace(test.name, `${test.name} ${testomatioMap.tests[test.name]}`)
       }
     }
+    files.push(file);
     fs.writeFile(file, fileContent, (err) => {
       if (err) throw err;
     });
   }
+  return files;
 }
 
-module.exports = { 
+module.exports = {
   hasStringArgument,
   hasTemplateQuasi,
   getLineNumber,
-  getEndLineNumber, 
-  getCode, 
-  hasTemplateArgument, 
+  getEndLineNumber,
+  getCode,
+  hasTemplateArgument,
   getQuasiArgument,
   parseComments,
   getStringValue,


### PR DESCRIPTION
* added `sync` toggle to process tests synchronously on backend (backend changes applied)
* `update-ids` are now executed as a part of import process, so can be used on a fresh new project. Sync mode is enabled. So when import is completed ids are updated.
* added `no-detach` option to disable marking tests as detached (backend changes applied)
* minor UX tweaks (was printing "✖️" when the response was 204, successful)
* Readme updated

These changes should also be applied to `check-cucumber` for consistency