### PR TITLE
[ISSUE-82]: skip & fixme condition for describe & test sections

### DIFF
--- a/example/playwright/fixme.js
+++ b/example/playwright/fixme.js
@@ -1,0 +1,57 @@
+// fixme.js
+const { test, expect } = require('@playwright/test');
+
+// Condition 1: test.describe.fixme => all inner tests skipped
+// Condition 2: test.describe.fixme + 1 inner fixme + 1 inner skip => all inner tests skipped
+// Condition 3: 1 inner fixme => only 1 skipped
+
+test.describe.fixme('fixme testing conditions: [rule 1]', () => {
+  test('test without status FIXME @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status FIXME @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status FIXME @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});
+
+test.describe.fixme('fixme testing conditions: [rule 2]', () => {
+  test('test without status FIXME @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test.skip('test with status SKIP @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test.fixme('test with status FIXME @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});
+
+test.describe('fixme testing conditions: [rule 3]', () => {
+  test('test without status SKIP @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test.fixme('test with status FIXME @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status SKIP @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});

--- a/example/playwright/skip.js
+++ b/example/playwright/skip.js
@@ -1,0 +1,57 @@
+// skip.js
+const { test, expect } = require('@playwright/test');
+
+// Condition 1: test.describe.skip => all inner tests skipped
+// Condition 2: test.describe.skip + 1 inner skip => all inner tests skipped
+// Condition 3: 1 inner skip => only 1 skipped
+
+test.describe.skip('skip testing conditions: [rule 1]', () => {
+  test('test without status SKIP @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status SKIP @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status SKIP @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});
+
+test.describe.skip('skip testing conditions: [rule 2]', () => {
+  test('test without status SKIP @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test.skip('test with status SKIP @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status SKIP @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});
+
+test.describe('skip testing conditions: [rule 3]', () => {
+  test('test without status SKIP @first', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test.skip('test with status SKIP @second', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+
+  test('test without status SKIP @third', async ({ page }) => {
+    // Assertions use the expect API.
+    await expect(page).toHaveURL('https://my.start.url/');
+  });
+});

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -32,9 +32,9 @@ module.exports = (ast, file = '', source = '') => {
         if (['describe', 'it', 'context', 'test'].includes(name)) {
           const line = getLineNumber(path);
           throw new CommentError(
-            'Exclusive tests detected. `.only` call found in '
-              + `${file}:${line}\n`
-              + 'Remove `.only` to restore test checks',
+            'Exclusive tests detected. `.only` call found in ' +
+              `${file}:${line}\n` +
+              'Remove `.only` to restore test checks',
           );
         }
       }
@@ -44,7 +44,8 @@ module.exports = (ast, file = '', source = '') => {
           return;
         }
 
-        const name = path.parent.object.name || path.parent.object.callee.object.name;
+        const name =
+          path.parent.object.name || path.parent.object.property.name || path.parent.object.callee.object.name;
 
         if (name === 'test' || name === 'it') {
           // test or it
@@ -79,7 +80,8 @@ module.exports = (ast, file = '', source = '') => {
           return;
         }
 
-        const name = path.parent.object.name || path.parent.object.callee.object.name;
+        const name =
+          path.parent.object.name || path.parent.object.property.name || path.parent.object.callee.object.name;
 
         if (name === 'test' || name === 'it') {
           // test or it


### PR DESCRIPTION
Issue  -  https://github.com/testomatio/check-tests/issues/82
1. I have updated condition for skip() and fixme() annotations => now we check not only inner tests, but also the parent suite too.
2. I have added 2 new tests which cover skip() and fixme()  cases(3 by skip() & 3 by fixme()) => all tests are PASSED after fix

![Screenshot-1](https://user-images.githubusercontent.com/82405549/229770773-e9e1d949-2a92-49dd-905f-c60f19a61343.png)

Now if someone use test.describe.skip() annotation => all inner tests should be skipped(no errors). All unit test conditions you can find in check-tests/tests/playwright_test.js file.
![Screenshot-2](https://user-images.githubusercontent.com/82405549/229771555-dbc1061d-31ad-43fd-a41d-f40731dde717.png)

