### PR TITLE
[ISSUE-80]: update-ids func inserts ids into import statements

### DIFF
--- a/src/updateIds.js
+++ b/src/updateIds.js
@@ -141,38 +141,24 @@ const parseSuite = suiteTitle => {
   return null;
 };
 
-const fixSuiteContent = (title, replace, content) => {
-  const importLines = content.split('\n').filter(line => line.match(LINE_START_REGEX));
-
-  if (importLines.length) {
-    const testLines = content.split('\n').filter(line => !line.match(LINE_START_REGEX));
-    const updatedTestLines = testLines.map(line => line.replace(title, replace));
-
-    return [...importLines, ...updatedTestLines].join('\n');
-  }
-
-  return content.replace(title, replace);
-};
-
 const replaceSuiteTitle = (title, replace, content) => {
   const lines = content.split('\n');
 
-  // try to find string near keyword
-  for (const lineNumber in lines) {
-    const line = lines[lineNumber];
-    for (const keyword of SUITE_KEYWORDS) {
-      if (line.match(keyword)) {
-        for (let i = lineNumber; i < lines.length; i++) {
-          if (lines[i].includes(title)) {
-            lines[i] = line.replace(title, replace);
-            return lines.join('\n');
-          }
+  // try to find string near keyword & exclude import lines
+  const updatedLines = lines.map(line => {
+    if (!line.match(LINE_START_REGEX)) {
+      for (const keyword of SUITE_KEYWORDS) {
+        if (line.match(keyword) || line.includes(title)) {
+          return line.replace(title, replace);
         }
+        return line;
       }
     }
-  }
 
-  return fixSuiteContent(title, replace, content);
+    return line;
+  });
+
+  return [...updatedLines].join('\n');
 };
 
 module.exports = {

--- a/src/updateIds.js
+++ b/src/updateIds.js
@@ -26,9 +26,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
     const currentSuiteId = parseSuite(suiteIndex);
     if (
-      currentSuiteId &&
-      testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
-      testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
+      currentSuiteId
+      && testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}`
+      && testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
     ) {
       debug(`   Previous ID detected in suite '${suiteIndex}'`);
       duplicateSuites++;
@@ -59,9 +59,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
       const currentTestId = parseTest(testIndex);
       if (
-        currentTestId &&
-        testomatioMap.tests[testIndex] !== `@T${currentTestId}` &&
-        testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
+        currentTestId
+        && testomatioMap.tests[testIndex] !== `@T${currentTestId}`
+        && testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
       ) {
         debug(`   Previous ID detected in test '${testIndex}'`);
         duplicateTests++;
@@ -143,22 +143,21 @@ const parseSuite = suiteTitle => {
 
 const replaceSuiteTitle = (title, replace, content) => {
   const lines = content.split('\n');
-
   // try to find string near keyword & exclude import lines
   const updatedLines = lines.map(line => {
-    if (!line.match(LINE_START_REGEX)) {
-      for (const keyword of SUITE_KEYWORDS) {
-        if (line.match(keyword) || line.includes(title)) {
-          return line.replace(title, replace);
-        }
-        return line;
-      }
-    }
+    // ignore lines with kewords
+    if (line.match(LINE_START_REGEX)) return line;
 
-    return line;
+    for (const keyword of SUITE_KEYWORDS) {
+      if (line.match(keyword) || line.includes(title)) {
+        return line.replace(title, replace);
+      }
+      
+      return line;
+    }
   });
 
-  return [...updatedLines].join('\n');
+  return updatedLines.join('\n');
 };
 
 module.exports = {

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -603,6 +603,7 @@ describe('update ids', () => {
 
       const updatedFile = fs.readFileSync('virtual_dir/test.ts', 'utf-8').toString();
 
+      expect(updatedFile).to.include("import { test, page } from '@playwright/test';");
       expect(updatedFile).to.include("import Example from '@src/Example';");
       expect(updatedFile).to.include("test.describe('Example @Sf3d245a7'");
       expect(updatedFile).to.include('test case #1 @T1d6a52b9');

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -584,8 +584,11 @@ describe('update ids', () => {
           import { test, page } from '@playwright/test';
           import Example from '@src/Example';
 
+          const userId = 1;
+
           test.describe('Example', () => {          
             test('test case #1', async ({ page }) => {
+              const opts = {"a": 1, "b": 2};
 
               await test.step('[Check 1] Open page and confirm title', async () => {
                 await page.goto("https://todomvc.com/examples/vanilla-es6/");
@@ -623,8 +626,11 @@ describe('update ids', () => {
         node_modules: mock.load(path.resolve(__dirname, '../node_modules')),
         virtual_dir: {
           'test.ts': `
+          const suite = "test";
+
           test.describe('Example', () => {          
             test('test case #1.1', async ({ page }) => {
+              let myVar = "msg";
 
               await test.step('[Check 1] Open page and confirm title', async () => {
                 await page.goto("https://todomvc.com/examples/vanilla-es6/");
@@ -669,7 +675,9 @@ describe('update ids', () => {
                 await page.goto("https://todomvc.com/examples/vanilla-es6/");
               });
             });
-          });`,
+          });
+          let msg = "some test case message";
+          `,
         },
       });
 


### PR DESCRIPTION
Fixes for https://github.com/testomatio/check-tests/issues/80 
I have added additional import handling for ts & js files. Like 
```
const fixSuiteContent = (title, replace, content) => {
  const importLines = content.split('\n').filter(line => line.match(LINE_START_REGEX));

  if (importLines.length) {
    const testLines = content.split('\n').filter(line => !line.match(LINE_START_REGEX));
    const updatedTestLines = testLines.map(line => line.replace(title, replace));

    return [...importLines, ...updatedTestLines].join('\n');
  }

  return content.replace(title, replace);
};
```
+ I have added 3 unit tests to test the example described in the ticket.
![Screenshot-test-1](https://user-images.githubusercontent.com/82405549/230668407-b07307de-cb1c-44b9-87c1-5bbe1129b836.png)
