### PR TITLE
[check-test#80] Update-ids inserts ids into import state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .env
 .vscode
 node_modules/
+
+# Output of 'npm pack'
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-tests",
-  "version": "0.8.13-beta.1.5.80",
+  "version": "0.8.12",
   "description": "Static analysis for tests. Prints all tests in console and fails when exclusive or skipped tests found.",
   "keywords": [
     "testing",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-tests",
-  "version": "0.8.12",
+  "version": "0.8.13-beta.1.5.80",
   "description": "Static analysis for tests. Prints all tests in console and fails when exclusive or skipped tests found.",
   "keywords": [
     "testing",

--- a/src/updateIds.js
+++ b/src/updateIds.js
@@ -29,9 +29,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
     const currentSuiteId = parseSuite(suiteIndex);
     if (
-      currentSuiteId &&
-      testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
-      testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
+      currentSuiteId
+      && testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}`
+      && testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
     ) {
       debug(`   Previous ID detected in suite '${suiteIndex}'`);
       duplicateSuites++;
@@ -62,9 +62,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
       const currentTestId = parseTest(testIndex);
       if (
-        currentTestId &&
-        testomatioMap.tests[testIndex] !== `@T${currentTestId}` &&
-        testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
+        currentTestId
+        && testomatioMap.tests[testIndex] !== `@T${currentTestId}`
+        && testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
       ) {
         debug(`   Previous ID detected in test '${testIndex}'`);
         duplicateTests++;

--- a/src/updateIds.js
+++ b/src/updateIds.js
@@ -24,6 +24,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
 
     const suite = testArr[0].suites[0] || '';
+
+    if (!suite) continue;
+
     const suiteIndex = suite;
     const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
 
@@ -106,14 +109,21 @@ function cleanIds(testData, testomatioMap = {}, workDir, opts = { dangerous: fal
     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
 
     const suite = testArr[0].suites[0];
-    const suiteId = `@S${parseSuite(suite)}`;
-    if (suiteIds.includes(suiteId) || (dangerous && suiteId)) {
-      const newTitle = suite.slice().replace(suiteId, '').trim();
-      fileContent = fileContent.replace(suite, newTitle);
+
+    if (suite) {
+      const suiteId = `@S${parseSuite(suite)}`;
+      debug('  clenaing suite: ', suite);
+
+      if (suiteIds.includes(suiteId) || (dangerous && suiteId)) {
+        const newTitle = suite.slice().replace(suiteId, '').trim();
+        fileContent = fileContent.replace(suite, newTitle);
+      }
     }
+
     for (const test of testArr) {
       const testId = `@T${parseTest(test.name)}`;
       debug('  clenaing test: ', test.name);
+
       if (testIds.includes(testId) || (dangerous && testId)) {
         fileContent = cleanAtPoint(fileContent, test.updatePoint, testId);
       }

--- a/src/updateIds.js
+++ b/src/updateIds.js
@@ -25,28 +25,28 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
     const suite = testArr[0].suites[0] || '';
 
-    if (!suite) continue;
+    if (suite) {
+      const suiteIndex = suite;
+      const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
 
-    const suiteIndex = suite;
-    const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
+      const currentSuiteId = parseSuite(suiteIndex);
+      if (
+        currentSuiteId &&
+        testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
+        testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
+      ) {
+        debug(`   Previous ID detected in suite '${suiteIndex}'`);
+        duplicateSuites++;
+        continue;
+      }
 
-    const currentSuiteId = parseSuite(suiteIndex);
-    if (
-      currentSuiteId
-      && testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}`
-      && testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
-    ) {
-      debug(`   Previous ID detected in suite '${suiteIndex}'`);
-      duplicateSuites++;
-      continue;
-    }
-
-    if (testomatioMap.suites[suiteIndex] && !suite.includes(testomatioMap.suites[suiteIndex])) {
-      fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteIndex]}`, fileContent);
-      fs.writeFileSync(file, fileContent);
-    } else if (testomatioMap.suites[suiteWithoutTags] && !suite.includes(testomatioMap.suites[suiteWithoutTags])) {
-      fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteWithoutTags]}`, fileContent);
-      fs.writeFileSync(file, fileContent);
+      if (testomatioMap.suites[suiteIndex] && !suite.includes(testomatioMap.suites[suiteIndex])) {
+        fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteIndex]}`, fileContent);
+        fs.writeFileSync(file, fileContent);
+      } else if (testomatioMap.suites[suiteWithoutTags] && !suite.includes(testomatioMap.suites[suiteWithoutTags])) {
+        fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteWithoutTags]}`, fileContent);
+        fs.writeFileSync(file, fileContent);
+      }
     }
 
     for (const test of testArr) {
@@ -65,9 +65,9 @@ function updateIds(testData, testomatioMap, workDir, opts = {}) {
 
       const currentTestId = parseTest(testIndex);
       if (
-        currentTestId
-        && testomatioMap.tests[testIndex] !== `@T${currentTestId}`
-        && testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
+        currentTestId &&
+        testomatioMap.tests[testIndex] !== `@T${currentTestId}` &&
+        testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
       ) {
         debug(`   Previous ID detected in test '${testIndex}'`);
         duplicateTests++;

--- a/tests/updateIds_playwright_test.js
+++ b/tests/updateIds_playwright_test.js
@@ -1,0 +1,190 @@
+/* eslint-disable no-template-curly-in-string */
+const { expect } = require('chai');
+const path = require('path');
+const mock = require('mock-fs');
+const fs = require('fs');
+const { updateIds } = require('../src/updateIds');
+const Analyzer = require('../src/analyzer');
+
+describe('update ids tests(playwright adapter)', () => {
+  afterEach(() => mock.restore());
+
+  describe('[Playwright examples] lines processing', () => {
+    it('[ts file]: the same import name as suite name', () => {
+      const analyzer = new Analyzer('playwright', 'virtual_dir');
+      analyzer.withTypeScript();
+      require('@babel/core');
+
+      const idMap = {
+        tests: {
+          'Example test case #1': '@T1d6a52b9',
+        },
+        suites: {
+          Example: '@Sf3d245a7',
+        },
+      };
+
+      mock({
+        node_modules: mock.load(path.resolve(__dirname, '../node_modules')),
+        virtual_dir: {
+          'test.ts': `
+          import { test, page } from '@playwright/test';
+          import Example from '@src/Example';
+
+          const userId = 1;
+
+          test.describe('Example', () => {          
+            test('Example test case #1', async ({ page }) => {
+              const opts = {"a": 1, "b": 2};
+
+              await test.step('[Check 1] Open Example page and confirm title', async () => {
+                await page.goto("https://todomvc.com/examples/vanilla-es6/");
+              });
+            });
+          });`,
+        },
+      });
+
+      analyzer.analyze('test.ts');
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir', { typescript: true });
+
+      const updatedFile = fs.readFileSync('virtual_dir/test.ts', 'utf-8').toString();
+
+      expect(updatedFile).to.include("import { test, page } from '@playwright/test';");
+      expect(updatedFile).to.include("import Example from '@src/Example';");
+      expect(updatedFile).to.include("test.describe('Example @Sf3d245a7'");
+      expect(updatedFile).to.include("test('Example test case #1 @T1d6a52b9'");
+      expect(updatedFile).to.include("test.step('[Check 1] Open Example page and confirm title'");
+    });
+
+    it('[ts file]: test file without imports should update only suite & test name', () => {
+      const analyzer = new Analyzer('playwright', 'virtual_dir');
+      analyzer.withTypeScript();
+      require('@babel/core');
+
+      const idMap = {
+        tests: {
+          'Example test case #1.1': '@T1d6a52b911',
+        },
+        suites: {
+          Example: '@Sf3d245a7',
+        },
+      };
+
+      mock({
+        node_modules: mock.load(path.resolve(__dirname, '../node_modules')),
+        virtual_dir: {
+          'test.ts': `
+          let Example = 'test';
+
+          test.describe('Example', () => {          
+            test('Example test case #1.1', async ({ page }) => {
+              let myVar = "msg";
+
+              await test.step('[Check 1] Open page and confirm title', async () => {
+                await page.goto("https://todomvc.com/examples/vanilla-es6/");
+              });
+            });
+          });`,
+        },
+      });
+
+      analyzer.analyze('test.ts');
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir', { typescript: true });
+
+      const updatedFile = fs.readFileSync('virtual_dir/test.ts', 'utf-8').toString();
+
+      expect(updatedFile).to.include("let Example = 'test';");
+      expect(updatedFile).to.include("test.describe('Example @Sf3d245a7'");
+      expect(updatedFile).to.include("test('Example test case #1.1 @T1d6a52b911'");
+    });
+
+    it('[js file]: the same require name as suite name', () => {
+      const analyzer = new Analyzer('playwright', 'virtual_dir');
+
+      const idMap = {
+        tests: {
+          'test case #2': '@T1d6a52b11',
+        },
+        suites: {
+          Example1: '@Sf3d245a71',
+        },
+      };
+
+      mock({
+        virtual_dir: {
+          'test.js': `
+          const { test, expect } = require('@playwright/test');
+          const Example2 = require('@src/Example1');
+          var Example1 = require('@src/lib/Example2');
+
+          test.describe('Example1', () => {          
+            test('test case #2', async ({ page }) => {
+
+              await test.step('[Check 1] Open page and confirm title', async () => {
+                await page.goto("https://todomvc.com/examples/vanilla-es6/");
+              });
+            });
+          });
+          let str = "some test case message";
+          `,
+        },
+      });
+
+      analyzer.analyze('test.js');
+
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
+
+      const updatedFile = fs.readFileSync('virtual_dir/test.js').toString();
+
+      expect(updatedFile).to.include("const Example2 = require('@src/Example1')");
+      expect(updatedFile).to.include("var Example1 = require('@src/lib/Example2');");
+      expect(updatedFile).to.include("test.describe('Example1 @Sf3d245a71'");
+      expect(updatedFile).to.include("test('test case #2 @T1d6a52b11'");
+      expect(updatedFile).to.include('let str = "some test case message";');
+    });
+
+    it('[js file]: suite name as a new line', () => {
+      const analyzer = new Analyzer('playwright', 'virtual_dir');
+
+      const idMap = {
+        tests: {
+          'test case #3': '@T1d6a52b119',
+        },
+        suites: {
+          'suite name': '@Sf3d245a719',
+        },
+      };
+
+      mock({
+        virtual_dir: {
+          'test.js': `
+          const { test, expect } = require('@playwright/test');
+
+          test.describe(
+            'suite name',
+            () => {          
+            test('test case #3', async ({ page }) => {
+
+              await test.step('[Check 1] Open page and confirm title', async () => {
+                await page.goto("https://todomvc.com/examples/vanilla-es6/");
+              });
+            });
+          });
+          `,
+        },
+      });
+
+      analyzer.analyze('test.js');
+
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
+
+      const updatedFile = fs.readFileSync('virtual_dir/test.js').toString();
+
+      expect(updatedFile).to.include("const { test, expect } = require('@playwright/test');");
+      expect(updatedFile).to.include('test.describe(');
+      expect(updatedFile).to.include("'suite name @Sf3d245a719',");
+      expect(updatedFile).to.include("test('test case #3 @T1d6a52b119', async ({ page }) => {");
+    });
+  });
+});


### PR DESCRIPTION
I have exclude import lines from the replaceSuiteTitle() function + added additional playwright tests to the new `updateIds_playwright_test.js` file => All new tests for the Playwright adapter can be added to this file. Plus small cleanIds fixes.