### PR TITLE
Display before and after for the tests for Codeceptjs & Playwright adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,16 @@ TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js"
 
 ```
 
+### Test code
+
+By default, check-test sends the code of the test hooks to the "client": before, beforeEach and after. 
+In the "Codes" section you can see all the additional "context" of the test (Testomat.io).
+
+To exclude hook code from a client test, use the --no-hooks option
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --no-hooks
+```
+
 ## Import Parametrized Tests
 
 It is possible to import parametrized tests if they use template literals with variables in thier names:

--- a/bin/check.js
+++ b/bin/check.js
@@ -46,12 +46,13 @@ program
     opts.framework = framework;
     opts.pattern = files;
     const isPattern = checkPattern(files);
+    const frameworkOpts = {};
 
     if (!opts.hooks) {
-      process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS = '1';
+      frameworkOpts.noHooks = true;
     }
 
-    const analyzer = new Analyzer(framework, opts.dir || process.cwd());
+    const analyzer = new Analyzer(framework, opts.dir || process.cwd(), frameworkOpts);
     try {
       if (opts.typescript) {
         try {

--- a/bin/check.js
+++ b/bin/check.js
@@ -49,7 +49,7 @@ program
     const frameworkOpts = {};
 
     if (!opts.hooks) {
-      frameworkOpts.noHooks = true;
+      frameworkOpts.noHooks = !opts.hooks;
     }
 
     const analyzer = new Analyzer(framework, opts.dir || process.cwd(), frameworkOpts);

--- a/bin/check.js
+++ b/bin/check.js
@@ -41,10 +41,16 @@ program
   .option('--no-empty', 'Remove empty suites after import')
   .option('--purge, --unsafe-clean-ids', 'Remove testomatio ids from test and suite without server verification')
   .option('--clean-ids', 'Remove testomatio ids from test and suite')
+  .option('--no-hooks', 'Exclude test hooks code from the code on the client')
   .action(async (framework, files, opts) => {
     opts.framework = framework;
     opts.pattern = files;
     const isPattern = checkPattern(files);
+
+    if (!opts.hooks) {
+      process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS = '1';
+    }
+
     const analyzer = new Analyzer(framework, opts.dir || process.cwd());
     try {
       if (opts.typescript) {

--- a/example/codeceptjs/test_hooks_description.js
+++ b/example/codeceptjs/test_hooks_description.js
@@ -1,0 +1,48 @@
+Feature('Get test description - Todos @step-11');
+
+Before(async (I, TodosPage) => {
+  TodosPage.goto();
+
+  TodosPage.enterTodo('foo');
+  TodosPage.enterTodo('bar');
+});
+
+BeforeSuite(({ I }) => {
+  TodosPage.enterTodo('baz');
+});
+
+Scenario('Edited todo is saved', async (I, TodosPage) => {
+  I.say('Given I have some todos');
+
+  I.say('When I edit the first todo');
+  await TodosPage.editNthTodo(1, 'boom');
+
+  I.say('Then I see that the todo text has been changed');
+  await TodosPage.seeNthTodoEquals(1, 'boom');
+});
+
+/**
+ * Edge cases
+ */
+
+const examples = new DataTable(['Todo Text', 'Result']);
+examples.add(['Todo with umlauts äöü', 'is in list']);
+examples.add([
+  'Very loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong TooooooooooooooooooooooooooooooooooooooooDooooooooooooooo',
+  'is in list',
+]);
+examples.add(['Todo with html code <script>alert("hello")</script>', 'is in list']);
+
+Data(examples).Scenario('Todos containing weird characters', async (I, current, TodosPage) => {
+  I.say('When I enter {Todo Text}');
+  TodosPage.enterTodo(current['Todo Text']);
+
+  I.say('Then I see {Result}');
+  if (current['Result'] === 'is in list') {
+    TodosPage.seeNthTodoEquals(1, current['Todo Text']);
+  }
+});
+
+AfterSuite(({ I }) => {
+  TodosPage.enterTodo('h&m');
+});

--- a/example/codeceptjs/test_hooks_description.js
+++ b/example/codeceptjs/test_hooks_description.js
@@ -2,7 +2,6 @@ Feature('Get test description - Todos @step-11');
 
 Before(async (I, TodosPage) => {
   TodosPage.goto();
-
   TodosPage.enterTodo('foo');
   TodosPage.enterTodo('bar');
 });

--- a/example/jest/hooks.spec.js
+++ b/example/jest/hooks.spec.js
@@ -1,0 +1,34 @@
+describe('test hooks', () => {
+    const foods = ["food1", "food2", "food3"]
+    // Applies only to tests in this describe block
+    beforeAll(() => {
+        console.log('Ran beforeAll');
+        expect(foods[1]).toBeTruthy();
+    });
+
+    beforeEach(() => {
+        console.log('Ran beforeEach');
+        expect(foods[2]).toBeTruthy();
+    });
+
+    test('Vienna <3 veal', async () => {
+        const { foods, pkg } = await generateWithPlugin({
+            id: 'router',
+            apply: require('../generator'),
+            options: {}
+        })
+
+        expect(foods['src/router/index.js']).toBeTruthy()
+    });
+
+    test('San Juan <3 plantains', async () => {
+        const foods = ["food1", "food2", "food3"];
+
+        expect(foods[1]).toBeTruthy()
+    });
+
+    afterAll(() => {
+        console.log('Ran afterAll');
+        expect(foods[0]).toBeTruthy();
+    });
+});

--- a/example/mocha/cypress_hooks.spec.js
+++ b/example/mocha/cypress_hooks.spec.js
@@ -1,0 +1,29 @@
+
+describe('Test Suite #1', function () {
+  context('Actions to test', () => {
+    beforeEach(() => {
+      console.log('Ran beforeEach');
+      cy.visit('http://localhost:8080/commands/actions');
+    })
+    before(() => {
+      console.log('Ran before');
+      cy.visit('http://localhost:8080/commands/actions');
+    })
+
+    it('.type() - type into a DOM element', () => {
+      // https://on.cypress.io/type
+      cy.get('.action-disabled')
+        .type('disabled error checking', { force: true })
+        .should('have.value', 'disabled error checking')
+    })
+
+    it('.click() - click on a DOM element', () => {
+      // https://on.cypress.io/click
+      cy.get('.action-btn').click();
+    })
+    after(async () => {
+      console.log('Ran after');
+      cy.get('.action-disabled');
+  });
+  })
+})

--- a/example/playwright/hooks.js
+++ b/example/playwright/hooks.js
@@ -1,0 +1,25 @@
+const { test, expect } = require('@playwright/test');
+test.describe('feature test hooks', () => {
+    test.beforeAll('run before', async () => {
+        console.log('Ran before');
+        await page.locator('#btnBeforeAll').click();
+    });
+    
+    test.beforeEach(async ({ page }) => {
+        console.log('Ran beforeEach');
+        await page.locator('#btnBeforeEach').click();
+    });
+  
+    test('my test #1', async ({ page }) => {
+        expect(page.url()).toBe('https://www.programsbuzz.com/');
+    });
+
+    test('my test #2', async ({ page }) => {
+        expect(page.url()).toBe('https://www.programsbuzz.com/');
+    });
+
+    test.afterAll(async () => {
+        console.log('Ran afterAll');
+        await page.locator('#btnafterAll').click();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-tests",
-  "version": "0.8.16",
+  "version": "0.8.17-beta-hooks",
   "description": "Static analysis for tests. Prints all tests in console and fails when exclusive or skipped tests found.",
   "keywords": [
     "testing",
@@ -68,7 +68,7 @@
   "scripts": {
     "check": "node -r dotenv/config bin/check.js",
     "run": "node -r dotenv/config index.js",
-    "test": "mocha tests/**_test.js -R ./node_modules/@testomatio/reporter/lib/adapter/mocha.js",
+    "test": "mocha tests/**_test.js",
     "lint": "eslint 'src/**/*.js' --fix",
     "pretty-quick": "pretty-quick --staged",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-tests",
-  "version": "0.8.17-beta-hooks",
+  "version": "0.8.17-beta-2",
   "description": "Static analysis for tests. Prints all tests in console and fails when exclusive or skipped tests found.",
   "keywords": [
     "testing",

--- a/src/analyzer.js
+++ b/src/analyzer.js
@@ -7,17 +7,19 @@ const Decorator = require('./decorator');
 let parser;
 
 /**
+ * @typedef {import('../types').Analyzer} Analyzer
  * @typedef {import('../types').Test} TestData
  */
 
 class Analyzer {
-  constructor(framework, workDir = '.') {
+  constructor(framework, workDir = '.', opts = {}) {
     this.framework = framework.toLowerCase();
     this.workDir = workDir;
     this.typeScript = false;
     this.plugins = [];
     this.presets = [];
     this.rawTests = [];
+    this.opts = opts;
 
     parser = require('@babel/parser');
 
@@ -144,7 +146,7 @@ class Analyzer {
        * Assigns the array of TestData objects to the `tests` variable.
        * @type {TestData[]}
        */
-      const testsData = this.frameworkParser(ast, fileName, source);
+      const testsData = this.frameworkParser(ast, fileName, source, this.opts);
       this.rawTests.push(testsData);
       const tests = new Decorator(testsData);
       this.stats.tests = this.stats.tests.concat(tests.getFullNames());

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -68,12 +68,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'Before' })) {
-        beforeCode = '';
         beforeCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
       }
 
       if (path.isIdentifier({ name: 'BeforeSuite' })) {
-        beforeSuiteCode = '';
         beforeSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
       }
 
@@ -114,7 +112,6 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'AfterSuite' })) {
-        afterSuiteCode = '';
         afterSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
 
         if (afterSuiteCode && !noHooks) {

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -30,7 +30,10 @@ module.exports = (ast, file = '', source = '') => {
         updatePoint: getUpdatePoint(path.container),
         line: getLineNumber(path),
         code:
-          beforeSuiteCode + beforeCode + getCode(source, getLineNumber(path), getEndLineNumber(path)) + afterSuiteCode,
+          beforeSuiteCode + 
+          beforeCode + 
+          getCode(source, getLineNumber(path), getEndLineNumber(path)) + 
+          afterSuiteCode,
         file,
       });
       return;

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -9,7 +9,7 @@ const {
   hasStringOrTemplateArgument,
 } = require('../utils');
 
-const withHooks = process.env.TESTOMATIO_WITH_HOOKS;
+const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
 
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
@@ -25,12 +25,12 @@ module.exports = (ast, file = '', source = '') => {
     beforeSuiteCode = beforeSuiteCode !== undefined ? beforeSuiteCode : '';
     afterSuiteCode = afterSuiteCode !== undefined ? afterSuiteCode : '';
 
-    code = withHooks
-      ? beforeSuiteCode +
+    code = withoutHooks
+      ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+      : beforeSuiteCode +
         beforeCode +
         getCode(source, getLineNumber(path), getEndLineNumber(path)) +
         afterSuiteCode
-      : getCode(source, getLineNumber(path), getEndLineNumber(path))
 
     if (hasStringOrTemplateArgument(path.container)) {
       const testName = getStringValue(path.container);
@@ -117,7 +117,7 @@ module.exports = (ast, file = '', source = '') => {
         afterSuiteCode = '';
         afterSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
 
-        if (withHooks && afterSuiteCode) {
+        if (afterSuiteCode && !withoutHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterSuiteCode)) {
               test.code += afterSuiteCode;

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -21,9 +21,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   const getScenario = path => {
     let code = '';
 
-    beforeCode = beforeCode !== undefined ? beforeCode : '';
-    beforeSuiteCode = beforeSuiteCode !== undefined ? beforeSuiteCode : '';
-    afterSuiteCode = afterSuiteCode !== undefined ? afterSuiteCode : '';
+    beforeCode = beforeCode ?? '';
+    beforeSuiteCode = beforeSuiteCode ?? '';
+    afterSuiteCode = afterSuiteCode ?? '';
 
     code = noHooks
       ? getCode(source, getLineNumber(path), getEndLineNumber(path))

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -9,11 +9,11 @@ const {
   hasStringOrTemplateArgument,
 } = require('../utils');
 
-const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
-
-module.exports = (ast, file = '', source = '') => {
+module.exports = (ast, file = '', source = '', opts = {}) => {
   const tests = [];
   let currentSuite = '';
+  // hooks variables
+  const noHooks = opts?.noHooks;
   let beforeCode = '';
   let beforeSuiteCode = '';
   let afterSuiteCode = '';
@@ -25,7 +25,7 @@ module.exports = (ast, file = '', source = '') => {
     beforeSuiteCode = beforeSuiteCode !== undefined ? beforeSuiteCode : '';
     afterSuiteCode = afterSuiteCode !== undefined ? afterSuiteCode : '';
 
-    code = withoutHooks
+    code = noHooks
       ? getCode(source, getLineNumber(path), getEndLineNumber(path))
       : beforeSuiteCode +
         beforeCode +
@@ -117,7 +117,7 @@ module.exports = (ast, file = '', source = '') => {
         afterSuiteCode = '';
         afterSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
 
-        if (afterSuiteCode && !withoutHooks) {
+        if (afterSuiteCode && !noHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterSuiteCode)) {
               test.code += afterSuiteCode;

--- a/src/lib/frameworks/jasmine.js
+++ b/src/lib/frameworks/jasmine.js
@@ -9,6 +9,7 @@ const {
   getCode,
 } = require('../utils');
 
+// if you need to expand the adapter with options, use opts = {}
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
   let currentSuite = [];
@@ -35,18 +36,18 @@ module.exports = (ast, file = '', source = '') => {
       if (path.isIdentifier({ name: 'fdescribe' })) {
         const line = getLineNumber(path);
         throw new CommentError(
-          'Exclusive tests detected. `fdescribe` call found in '
-            + `${file}:${line}\n`
-            + 'Remove `fdescibe` to restore test checks',
+          'Exclusive tests detected. `fdescribe` call found in ' +
+            `${file}:${line}\n` +
+            'Remove `fdescibe` to restore test checks',
         );
       }
 
       if (path.isIdentifier({ name: 'fit' })) {
         const line = getLineNumber(path);
         throw new CommentError(
-          'Exclusive tests detected. `fit` call found in '
-            + `${file}:${line}\n`
-            + 'Remove `fit` to restore test checks',
+          'Exclusive tests detected. `fit` call found in ' +
+            `${file}:${line}\n` +
+            'Remove `fit` to restore test checks',
         );
       }
 

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -9,11 +9,11 @@ const {
   getCode,
 } = require('../utils');
 
-const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
-
-module.exports = (ast, file = '', source = '') => {
+module.exports = (ast, file = '', source = '', opts = {}) => {
   const tests = [];
   let currentSuite = [];
+  // hooks variables
+  const noHooks = opts?.noHooks;
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -44,7 +44,7 @@ module.exports = (ast, file = '', source = '') => {
         afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
-        if (afterCode && !withoutHooks) {
+        if (afterCode && !noHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterCode)) {
               test.code += afterCode;
@@ -130,7 +130,7 @@ module.exports = (ast, file = '', source = '') => {
         beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
         afterCode = afterCode !== undefined ? afterCode : '';
 
-        code = withoutHooks
+        code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))
           : beforeEachCode +
             beforeCode +

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -31,17 +31,14 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'beforeAll' })) {
-        beforeCode = '';
         beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = '';
         beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'afterAll' })) {
-        afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
         if (afterCode && !noHooks) {

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -126,9 +126,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         let code = '';
 
-        beforeCode = beforeCode !== undefined ? beforeCode : '';
-        beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
-        afterCode = afterCode !== undefined ? afterCode : '';
+        beforeCode = beforeCode ?? '';
+        beforeEachCode = beforeEachCode ?? '';
+        afterCode = afterCode ?? '';
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -9,9 +9,14 @@ const {
   getCode,
 } = require('../utils');
 
+const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
+
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
   let currentSuite = [];
+  let beforeCode = '';
+  let beforeEachCode = '';
+  let afterCode = '';
 
   function addSuite(path) {
     currentSuite = currentSuite.filter(s => s.loc.end.line > path.loc.start.line);
@@ -23,6 +28,29 @@ module.exports = (ast, file = '', source = '') => {
       if (path.isIdentifier({ name: 'describe' })) {
         if (!hasStringOrTemplateArgument(path.parent)) return;
         addSuite(path.parent);
+      }
+
+      if (path.isIdentifier({ name: 'beforeAll' })) {
+        beforeCode = '';
+        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+      }
+
+      if (path.isIdentifier({ name: 'beforeEach' })) {
+        beforeEachCode = '';
+        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+      }
+
+      if (path.isIdentifier({ name: 'afterAll' })) {
+        afterCode = '';
+        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+
+        if (afterCode && !withoutHooks) {
+          for (const test of tests) {
+            if (!test.code.includes(afterCode)) {
+              test.code += afterCode;
+            }
+          }
+        }
       }
 
       // forbid only
@@ -96,13 +124,26 @@ module.exports = (ast, file = '', source = '') => {
       if (path.isIdentifier({ name: 'test' }) || path.isIdentifier({ name: 'it' })) {
         if (!hasStringOrTemplateArgument(path.parent)) return;
 
+        let code = '';
+
+        beforeCode = beforeCode !== undefined ? beforeCode : '';
+        beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
+        afterCode = afterCode !== undefined ? afterCode : '';
+
+        code = withoutHooks
+          ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+          : beforeEachCode +
+            beforeCode +
+            getCode(source, getLineNumber(path), getEndLineNumber(path)) +
+            afterCode;
+
         const testName = getStringValue(path.parent);
         tests.push({
           name: testName,
           suites: currentSuite.map(s => getStringValue(s)),
           updatePoint: getUpdatePoint(path.parent),
           line: getLineNumber(path),
-          code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+          code,
           file,
           skipped: !!currentSuite.filter(s => s.skipped).length,
         });

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -36,17 +36,14 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'before' })) {
-        beforeCode = '';
         beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = '';
         beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'after' })) {
-        afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
         if (afterCode && !noHooks) {

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -123,9 +123,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         let code = '';
 
-        beforeCode = beforeCode !== undefined ? beforeCode : '';
-        beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
-        afterCode = afterCode !== undefined ? afterCode : '';
+        beforeCode = beforeCode ?? '';
+        beforeEachCode = beforeEachCode ?? '';
+        afterCode = afterCode ?? '';
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -6,8 +6,9 @@ const {
   hasStringOrTemplateArgument,
   getLineNumber,
   getEndLineNumber,
-  getCode
+  getCode,
 } = require('../utils');
+
 const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
 
 module.exports = (ast, file = '', source = '') => {

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -9,11 +9,11 @@ const {
   getCode,
 } = require('../utils');
 
-const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
-
-module.exports = (ast, file = '', source = '') => {
+module.exports = (ast, file = '', source = '', opts = {}) => {
   const tests = [];
   let currentSuite = [];
+  // hooks variables
+  const noHooks = opts?.noHooks;
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -49,7 +49,7 @@ module.exports = (ast, file = '', source = '') => {
         afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
-        if (afterCode && !withoutHooks) {
+        if (afterCode && !noHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterCode)) {
               test.code += afterCode;
@@ -127,7 +127,7 @@ module.exports = (ast, file = '', source = '') => {
         beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
         afterCode = afterCode !== undefined ? afterCode : '';
 
-        code = withoutHooks
+        code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))
           : beforeEachCode +
             beforeCode +

--- a/src/lib/frameworks/newman.js
+++ b/src/lib/frameworks/newman.js
@@ -1,6 +1,7 @@
 const debug = require('debug')('check-tests:newman');
 
 // ast and file will be ignored
+// if you need to expand the adapter with options, use opts = {}
 module.exports = (ast = '', file = '', source = '') => {
   const collection = JSON.parse(source);
   debug('Collection:\n', collection);

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -162,9 +162,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         let code = '';
 
-        beforeCode = beforeCode !== undefined ? beforeCode : '';
-        beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
-        afterCode = afterCode !== undefined ? afterCode : '';
+        beforeCode = beforeCode ?? '';
+        beforeEachCode = beforeEachCode ?? '';
+        afterCode = afterCode ?? '';
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -9,11 +9,11 @@ const {
   getCode,
 } = require('../utils');
 
-const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
-
-module.exports = (ast, file = '', source = '') => {
+module.exports = (ast, file = '', source = '', opts = {}) => {
   const tests = [];
   let currentSuite = [];
+  // hooks variables
+  const noHooks = opts?.noHooks;
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -45,7 +45,7 @@ module.exports = (ast, file = '', source = '') => {
         afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
-        if (afterCode && !withoutHooks) {
+        if (afterCode && !noHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterCode)) {
               test.code += afterCode;
@@ -166,7 +166,7 @@ module.exports = (ast, file = '', source = '') => {
         beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
         afterCode = afterCode !== undefined ? afterCode : '';
 
-        code = withoutHooks
+        code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path))
           : beforeEachCode +
             beforeCode +

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -9,7 +9,7 @@ const {
   getCode,
 } = require('../utils');
 
-const withHooks = process.env.TESTOMATIO_WITH_HOOKS;
+const withoutHooks = process.env.TESTOMATIO_IMPORT_WITHOUT_HOOKS;
 
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
@@ -45,7 +45,7 @@ module.exports = (ast, file = '', source = '') => {
         afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
-        if (withHooks && afterCode) {
+        if (afterCode && !withoutHooks) {
           for (const test of tests) {
             if (!test.code.includes(afterCode)) {
               test.code += afterCode;
@@ -166,12 +166,12 @@ module.exports = (ast, file = '', source = '') => {
         beforeEachCode = beforeEachCode !== undefined ? beforeEachCode : '';
         afterCode = afterCode !== undefined ? afterCode : '';
 
-        code = withHooks
-          ? beforeEachCode +
+        code = withoutHooks
+          ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+          : beforeEachCode +
             beforeCode +
             getCode(source, getLineNumber(path), getEndLineNumber(path)) +
-            afterCode
-          : getCode(source, getLineNumber(path), getEndLineNumber(path))
+            afterCode;
 
         const testName = getStringValue(path.parent);
 

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -32,17 +32,14 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'beforeAll' })) {
-        beforeCode = '';
         beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = '';
         beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
       }
 
       if (path.isIdentifier({ name: 'afterAll' })) {
-        afterCode = '';
         afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
 
         if (afterCode && !noHooks) {

--- a/src/lib/frameworks/qunit.js
+++ b/src/lib/frameworks/qunit.js
@@ -9,6 +9,7 @@ const {
   getCode,
 } = require('../utils');
 
+// if you need to expand the adapter with options, use opts = {}
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
   let currentSuite = [];
@@ -32,9 +33,9 @@ module.exports = (ast, file = '', source = '') => {
         if (['describe', 'it', 'context', 'test'].includes(name)) {
           const line = getLineNumber(path);
           throw new CommentError(
-            'Exclusive tests detected. `.only` call found in '
-              + `${file}:${line}\n`
-              + 'Remove `.only` to restore test checks',
+            'Exclusive tests detected. `.only` call found in ' +
+              `${file}:${line}\n` +
+              'Remove `.only` to restore test checks',
           );
         }
       }

--- a/src/lib/frameworks/testcafe.js
+++ b/src/lib/frameworks/testcafe.js
@@ -10,6 +10,7 @@ const {
   getQuasiArgument,
 } = require('../utils');
 
+// if you need to expand the adapter with options, use opts = {}
 module.exports = (ast, file = '', source = '') => {
   const tests = [];
   let currentSuite = '';
@@ -22,10 +23,7 @@ module.exports = (ast, file = '', source = '') => {
       }
 
       if (path.isIdentifier({ name: 'test' })) {
-        if (
-          !hasStringArgument(path.parent)
-          && !hasTemplateArgument(path.parent)
-        ) return;
+        if (!hasStringArgument(path.parent) && !hasTemplateArgument(path.parent)) return;
 
         let testName = path.parent.arguments[0].value;
         if (!testName) {
@@ -49,10 +47,7 @@ module.exports = (ast, file = '', source = '') => {
 
         if (path.parent.object.name === 'test') {
           // test
-          if (
-            !hasStringArgument(path.parentPath.container)
-            && !hasTemplateArgument(path.parentPath.container)
-          ) return;
+          if (!hasStringArgument(path.parentPath.container) && !hasTemplateArgument(path.parentPath.container)) return;
 
           const testName = path.parentPath.container.arguments[0].value;
           tests.push({
@@ -60,11 +55,7 @@ module.exports = (ast, file = '', source = '') => {
             suites: [currentSuite],
             updatePoint: getUpdatePoint(path.parent),
             line: getLineNumber(path),
-            code: getCode(
-              source,
-              getLineNumber(path.parentPath),
-              getEndLineNumber(path.parentPath),
-            ),
+            code: getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath)),
             file,
             skipped: true,
           });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -82,6 +82,13 @@ function getEndLineNumber(path) {
 function getCode(source, start, end) {
   if (!start || !end || !source) return '';
   const lines = source.split('\n');
+
+  for (let i = start - 1; i < end; i++) {
+    if (lines[i].trim().endsWith('})') || lines[i].trim().endsWith('});')) {
+      lines[i] += '\n';
+    }
+  }
+
   return lines.slice(start - 1, end).join('\n');
 }
 
@@ -111,7 +118,8 @@ function replaceAtPoint(subject, replaceAt, replaceTo) {
   if (updateLine.includes('|')) {
     lines[replaceAt.line - 1] = updateLine.replace(' |', `${replaceTo} |`);
   } else {
-    lines[replaceAt.line - 1] = updateLine.substring(0, replaceAt.column) + replaceTo + updateLine.substring(replaceAt.column);
+    lines[replaceAt.line - 1] =
+      updateLine.substring(0, replaceAt.column) + replaceTo + updateLine.substring(replaceAt.column);
   }
   return lines.join('\n');
 }

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -1,6 +1,7 @@
 const parser = require('@babel/parser');
 const fs = require('fs');
 const { expect } = require('chai');
+// const mockedEnv = require('mocked-env'); //TODO:
 const codeceptParser = require('../src/lib/frameworks/codeceptjs');
 
 let source;
@@ -67,7 +68,7 @@ describe('codeceptjs parser', () => {
     });
   });
 
-  context('Parse CodeceptJS hooks code', () => {
+  context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
     let fileSource,
       fileAst = '';
     before(() => {
@@ -75,38 +76,76 @@ describe('codeceptjs parser', () => {
       fileAst = parser.parse(fileSource);
     });
 
-    it('should include Before hook code', () => {
+    it('should exclude Before hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("Before(async (I, TodosPage) => {\n");
-      expect(tests[0].code).to.include("TodosPage.goto();\n");
-      expect(tests[0].code).to.include("TodosPage.enterTodo('foo');\n");
-      expect(tests[0].code).to.include("TodosPage.enterTodo('bar');\n");
+      expect(tests[0].code).to.not.include('Before(async (I, TodosPage) => {\n');
       // second test
-      expect(tests[1].code).to.include("Before(async (I, TodosPage) => {\n");
-      expect(tests[1].code).to.include("TodosPage.goto();\n");
-      expect(tests[1].code).to.include("TodosPage.enterTodo('foo');\n");
-      expect(tests[1].code).to.include("TodosPage.enterTodo('bar');\n");
+      expect(tests[1].code).to.not.include('Before(async (I, TodosPage) => {\n');
     });
 
-    it('should include BeforeSuite hook code', () => {
+    it('should exclude BeforeSuite hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("BeforeSuite(({ I }) => {\n");
-      expect(tests[0].code).to.include("TodosPage.enterTodo('baz');\n");
+      expect(tests[0].code).to.not.include('BeforeSuite(({ I }) => {\n');
       // second test
-      expect(tests[1].code).to.include("BeforeSuite(({ I }) => {\n");
-      expect(tests[1].code).to.include("TodosPage.enterTodo('baz');\n");
+      expect(tests[1].code).to.not.include('BeforeSuite(({ I }) => {\n');
     });
 
-    it('should include AfterSuite hook code', () => {
+    it('should exclude AfterSuite hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("AfterSuite(({ I }) => {\n");
-      expect(tests[0].code).to.include("TodosPage.enterTodo('h&m');\n");
+      expect(tests[0].code).to.not.include('AfterSuite(({ I }) => {\n');
       // second test
-      expect(tests[1].code).to.include("AfterSuite(({ I }) => {\n");
-      expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
+      expect(tests[1].code).to.not.include('AfterSuite(({ I }) => {\n');
     });
   });
+  //TODO: need SET "TESTOMATIO_WITH_HOOKS": "1" in test
+  // context('[with TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
+  //   let fileSource,
+  //     fileAst = '';
+
+  //   before(function () {
+  //     restore = mockedEnv({
+  //       "TESTOMATIO_WITH_HOOKS": "1",
+  //     })
+
+  //     fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
+  //     fileAst = parser.parse(fileSource);
+  //   });
+
+  //   it('should include Before hook code', () => {
+  //     const tests = codeceptParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("Before(async (I, TodosPage) => {\n");
+  //     expect(tests[0].code).to.include("TodosPage.goto();\n");
+  //     expect(tests[0].code).to.include("TodosPage.enterTodo('foo');\n");
+  //     expect(tests[0].code).to.include("TodosPage.enterTodo('bar');\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("Before(async (I, TodosPage) => {\n");
+  //     expect(tests[1].code).to.include("TodosPage.goto();\n");
+  //     expect(tests[1].code).to.include("TodosPage.enterTodo('foo');\n");
+  //     expect(tests[1].code).to.include("TodosPage.enterTodo('bar');\n");
+  //   });
+
+  //   it('should include BeforeSuite hook code', () => {
+  //     const tests = codeceptParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("BeforeSuite(({ I }) => {\n");
+  //     expect(tests[0].code).to.include("TodosPage.enterTodo('baz');\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("BeforeSuite(({ I }) => {\n");
+  //     expect(tests[1].code).to.include("TodosPage.enterTodo('baz');\n");
+  //   });
+
+  //   it('should include AfterSuite hook code', () => {
+  //     const tests = codeceptParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("AfterSuite(({ I }) => {\n");
+  //     expect(tests[0].code).to.include("TodosPage.enterTodo('h&m');\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("AfterSuite(({ I }) => {\n");
+  //     expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
+  //   });
+  // });
 });

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -75,25 +75,38 @@ describe('codeceptjs parser', () => {
       fileAst = parser.parse(fileSource);
     });
 
-    it('should include AfterSuite hook code', () => {
+    it('should include Before hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
-
-      expect(tests[0].code).to.include('AfterSuite(({ I }) => {\n');
-      expect(tests[1].code).to.include('AfterSuite(({ I }) => {\n');
+      // first test
+      expect(tests[0].code).to.include("Before(async (I, TodosPage) => {\n");
+      expect(tests[0].code).to.include("TodosPage.goto();\n");
+      expect(tests[0].code).to.include("TodosPage.enterTodo('foo');\n");
+      expect(tests[0].code).to.include("TodosPage.enterTodo('bar');\n");
+      // second test
+      expect(tests[1].code).to.include("Before(async (I, TodosPage) => {\n");
+      expect(tests[1].code).to.include("TodosPage.goto();\n");
+      expect(tests[1].code).to.include("TodosPage.enterTodo('foo');\n");
+      expect(tests[1].code).to.include("TodosPage.enterTodo('bar');\n");
     });
 
     it('should include BeforeSuite hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
-
-      expect(tests[0].code).to.include('BeforeSuite(({ I }) => {\n');
-      expect(tests[1].code).to.include('BeforeSuite(({ I }) => {\n');
+      // first test
+      expect(tests[0].code).to.include("BeforeSuite(({ I }) => {\n");
+      expect(tests[0].code).to.include("TodosPage.enterTodo('baz');\n");
+      // second test
+      expect(tests[1].code).to.include("BeforeSuite(({ I }) => {\n");
+      expect(tests[1].code).to.include("TodosPage.enterTodo('baz');\n");
     });
 
-    it('should include Before hook code', () => {
+    it('should include AfterSuite hook code', () => {
       const tests = codeceptParser(fileAst, '', fileSource);
-
-      expect(tests[0].code).to.include('Before(async (I, TodosPage) => {\n');
-      expect(tests[1].code).to.include('Before(async (I, TodosPage) => {\n');
+      // first test
+      expect(tests[0].code).to.include("AfterSuite(({ I }) => {\n");
+      expect(tests[0].code).to.include("TodosPage.enterTodo('h&m');\n");
+      // second test
+      expect(tests[1].code).to.include("AfterSuite(({ I }) => {\n");
+      expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
     });
   });
 });

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -1,7 +1,6 @@
 const parser = require('@babel/parser');
 const fs = require('fs');
 const { expect } = require('chai');
-// const mockedEnv = require('mocked-env'); //TODO:
 const codeceptParser = require('../src/lib/frameworks/codeceptjs');
 
 let source;
@@ -67,85 +66,81 @@ describe('codeceptjs parser', () => {
       expect(actualTests).to.include('Search on Google @product-search @classic-test');
     });
   });
-
-  context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
-    let fileSource,
-      fileAst = '';
-    before(() => {
-      fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
-      fileAst = parser.parse(fileSource);
-    });
-
-    it('should exclude Before hook code', () => {
-      const tests = codeceptParser(fileAst, '', fileSource);
-      // first test
-      expect(tests[0].code).to.not.include('Before(async (I, TodosPage) => {\n');
-      // second test
-      expect(tests[1].code).to.not.include('Before(async (I, TodosPage) => {\n');
-    });
-
-    it('should exclude BeforeSuite hook code', () => {
-      const tests = codeceptParser(fileAst, '', fileSource);
-      // first test
-      expect(tests[0].code).to.not.include('BeforeSuite(({ I }) => {\n');
-      // second test
-      expect(tests[1].code).to.not.include('BeforeSuite(({ I }) => {\n');
-    });
-
-    it('should exclude AfterSuite hook code', () => {
-      const tests = codeceptParser(fileAst, '', fileSource);
-      // first test
-      expect(tests[0].code).to.not.include('AfterSuite(({ I }) => {\n');
-      // second test
-      expect(tests[1].code).to.not.include('AfterSuite(({ I }) => {\n');
-    });
-  });
-  //TODO: need SET "TESTOMATIO_WITH_HOOKS": "1" in test
-  // context('[with TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
+  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
+  // context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
   //   let fileSource,
   //     fileAst = '';
-
-  //   before(function () {
-  //     restore = mockedEnv({
-  //       "TESTOMATIO_WITH_HOOKS": "1",
-  //     })
-
+  //   before(() => {
   //     fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
   //     fileAst = parser.parse(fileSource);
   //   });
 
-  //   it('should include Before hook code', () => {
-  //     const tests = codeceptParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("Before(async (I, TodosPage) => {\n");
-  //     expect(tests[0].code).to.include("TodosPage.goto();\n");
-  //     expect(tests[0].code).to.include("TodosPage.enterTodo('foo');\n");
-  //     expect(tests[0].code).to.include("TodosPage.enterTodo('bar');\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("Before(async (I, TodosPage) => {\n");
-  //     expect(tests[1].code).to.include("TodosPage.goto();\n");
-  //     expect(tests[1].code).to.include("TodosPage.enterTodo('foo');\n");
-  //     expect(tests[1].code).to.include("TodosPage.enterTodo('bar');\n");
-  //   });
-
-  //   it('should include BeforeSuite hook code', () => {
-  //     const tests = codeceptParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("BeforeSuite(({ I }) => {\n");
-  //     expect(tests[0].code).to.include("TodosPage.enterTodo('baz');\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("BeforeSuite(({ I }) => {\n");
-  //     expect(tests[1].code).to.include("TodosPage.enterTodo('baz');\n");
-  //   });
-
-  //   it('should include AfterSuite hook code', () => {
-  //     const tests = codeceptParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("AfterSuite(({ I }) => {\n");
-  //     expect(tests[0].code).to.include("TodosPage.enterTodo('h&m');\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("AfterSuite(({ I }) => {\n");
-  //     expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
-  //   });
+  // it('should exclude Before hook code', () => {
+  //   const tests = codeceptParser(fileAst, '', fileSource);
+  //   // first test
+  //   expect(tests[0].code).to.not.include('Before(async (I, TodosPage) => {\n');
+  //   // second test
+  //   expect(tests[1].code).to.not.include('Before(async (I, TodosPage) => {\n');
   // });
+
+  // it('should exclude BeforeSuite hook code', () => {
+  //   const tests = codeceptParser(fileAst, '', fileSource);
+  //   // first test
+  //   expect(tests[0].code).to.not.include('BeforeSuite(({ I }) => {\n');
+  //   // second test
+  //   expect(tests[1].code).to.not.include('BeforeSuite(({ I }) => {\n');
+  // });
+
+  // it('should exclude AfterSuite hook code', () => {
+  //   const tests = codeceptParser(fileAst, '', fileSource);
+  //   // first test
+  //   expect(tests[0].code).to.not.include('AfterSuite(({ I }) => {\n');
+  //   // second test
+  //   expect(tests[1].code).to.not.include('AfterSuite(({ I }) => {\n');
+  // });
+  // });
+
+  context('Parse CodeceptJS hooks code - default opts', () => {
+    let fileSource,
+      fileAst = '';
+
+    before(function () {
+      fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
+      fileAst = parser.parse(fileSource);
+    });
+
+    it('should include Before hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include('Before(async (I, TodosPage) => {\n');
+      expect(tests[0].code).to.include('TodosPage.goto();\n');
+      expect(tests[0].code).to.include("TodosPage.enterTodo('foo');\n");
+      expect(tests[0].code).to.include("TodosPage.enterTodo('bar');\n");
+      // second test
+      expect(tests[1].code).to.include('Before(async (I, TodosPage) => {\n');
+      expect(tests[1].code).to.include('TodosPage.goto();\n');
+      expect(tests[1].code).to.include("TodosPage.enterTodo('foo');\n");
+      expect(tests[1].code).to.include("TodosPage.enterTodo('bar');\n");
+    });
+
+    it('should include BeforeSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include('BeforeSuite(({ I }) => {\n');
+      expect(tests[0].code).to.include("TodosPage.enterTodo('baz');\n");
+      // second test
+      expect(tests[1].code).to.include('BeforeSuite(({ I }) => {\n');
+      expect(tests[1].code).to.include("TodosPage.enterTodo('baz');\n");
+    });
+
+    it('should include AfterSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include('AfterSuite(({ I }) => {\n');
+      expect(tests[0].code).to.include("TodosPage.enterTodo('h&m');\n");
+      // second test
+      expect(tests[1].code).to.include('AfterSuite(({ I }) => {\n');
+      expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
+    });
+  });
 });

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -51,9 +51,7 @@ describe('codeceptjs parser', () => {
     });
   });
 
-
   context('Parse CodeceptJS tags & datatable', () => {
-
     before(() => {
       source = fs.readFileSync('./example/codeceptjs/data_table_tags_test.js').toString();
       ast = parser.parse(source);
@@ -69,5 +67,33 @@ describe('codeceptjs parser', () => {
     });
   });
 
+  context('Parse CodeceptJS hooks code', () => {
+    let fileSource,
+      fileAst = '';
+    before(() => {
+      fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
+      fileAst = parser.parse(fileSource);
+    });
 
+    it('should include AfterSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+
+      expect(tests[0].code).to.include('AfterSuite(({ I }) => {\n');
+      expect(tests[1].code).to.include('AfterSuite(({ I }) => {\n');
+    });
+
+    it('should include BeforeSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+
+      expect(tests[0].code).to.include('BeforeSuite(({ I }) => {\n');
+      expect(tests[1].code).to.include('BeforeSuite(({ I }) => {\n');
+    });
+
+    it('should include Before hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource);
+
+      expect(tests[0].code).to.include('Before(async (I, TodosPage) => {\n');
+      expect(tests[1].code).to.include('Before(async (I, TodosPage) => {\n');
+    });
+  });
 });

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -111,8 +111,7 @@ describe('codeceptjs parser', () => {
     });
   });
 
-  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
-  context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
+  context('[without noHooks=true] Parse CodeceptJS hooks code', () => {
     let fileSource,
       fileAst = '';
     before(() => {

--- a/tests/codeceptjs_test.js
+++ b/tests/codeceptjs_test.js
@@ -66,39 +66,6 @@ describe('codeceptjs parser', () => {
       expect(actualTests).to.include('Search on Google @product-search @classic-test');
     });
   });
-  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
-  // context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
-  //   let fileSource,
-  //     fileAst = '';
-  //   before(() => {
-  //     fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
-  //     fileAst = parser.parse(fileSource);
-  //   });
-
-  // it('should exclude Before hook code', () => {
-  //   const tests = codeceptParser(fileAst, '', fileSource);
-  //   // first test
-  //   expect(tests[0].code).to.not.include('Before(async (I, TodosPage) => {\n');
-  //   // second test
-  //   expect(tests[1].code).to.not.include('Before(async (I, TodosPage) => {\n');
-  // });
-
-  // it('should exclude BeforeSuite hook code', () => {
-  //   const tests = codeceptParser(fileAst, '', fileSource);
-  //   // first test
-  //   expect(tests[0].code).to.not.include('BeforeSuite(({ I }) => {\n');
-  //   // second test
-  //   expect(tests[1].code).to.not.include('BeforeSuite(({ I }) => {\n');
-  // });
-
-  // it('should exclude AfterSuite hook code', () => {
-  //   const tests = codeceptParser(fileAst, '', fileSource);
-  //   // first test
-  //   expect(tests[0].code).to.not.include('AfterSuite(({ I }) => {\n');
-  //   // second test
-  //   expect(tests[1].code).to.not.include('AfterSuite(({ I }) => {\n');
-  // });
-  // });
 
   context('Parse CodeceptJS hooks code - default opts', () => {
     let fileSource,
@@ -141,6 +108,40 @@ describe('codeceptjs parser', () => {
       // second test
       expect(tests[1].code).to.include('AfterSuite(({ I }) => {\n');
       expect(tests[1].code).to.include("TodosPage.enterTodo('h&m');\n");
+    });
+  });
+
+  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
+  context('[without TESTOMATIO-WITH-HOOKS env] Parse CodeceptJS hooks code', () => {
+    let fileSource,
+      fileAst = '';
+    before(() => {
+      fileSource = fs.readFileSync('./example/codeceptjs/test_hooks_description.js').toString();
+      fileAst = parser.parse(fileSource);
+    });
+
+    it('should exclude Before hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('Before(async (I, TodosPage) => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('Before(async (I, TodosPage) => {\n');
+    });
+
+    it('should exclude BeforeSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('BeforeSuite(({ I }) => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('BeforeSuite(({ I }) => {\n');
+    });
+
+    it('should exclude AfterSuite hook code', () => {
+      const tests = codeceptParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('AfterSuite(({ I }) => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('AfterSuite(({ I }) => {\n');
     });
   });
 });

--- a/tests/jest_test.js
+++ b/tests/jest_test.js
@@ -7,53 +7,53 @@ let source;
 let ast;
 
 describe('jest parser', () => {
-  // context('jest tests', () => {
-  //   before(() => {
-  //     source = fs.readFileSync('./example/jest/vue.spec.js').toString();
-  //     ast = parser.parse(source);
-  //   });
+  context('jest tests', () => {
+    before(() => {
+      source = fs.readFileSync('./example/jest/vue.spec.js').toString();
+      ast = parser.parse(source);
+    });
 
-  //   it('should parse jest file', () => {
-  //     const tests = jestParser(ast);
+    it('should parse jest file', () => {
+      const tests = jestParser(ast);
 
-  //     const actualTests = tests.filter(t => !t.skipped).map(t => t.name);
-  //     const skippedTests = tests.filter(t => t.skipped).map(t => t.name);
+      const actualTests = tests.filter(t => !t.skipped).map(t => t.name);
+      const skippedTests = tests.filter(t => t.skipped).map(t => t.name);
 
-  //     expect(actualTests).to.include('base');
-  //     expect(actualTests).to.include('history mode');
-  //     expect(actualTests).to.include('file should exist');
-  //     expect(actualTests).to.include('%i file should exist (it.each)');
+      expect(actualTests).to.include('base');
+      expect(actualTests).to.include('history mode');
+      expect(actualTests).to.include('file should exist');
+      expect(actualTests).to.include('%i file should exist (it.each)');
 
-  //     expect(skippedTests).to.include('skip: use with Babel (test)');
-  //     expect(skippedTests).to.include('skip: use with Babel (it)');
-  //     expect(skippedTests).to.include('skip: %i file should exist (it.each)');
-  //     expect(skippedTests).to.include('skip: %i file should exist (test.each)');
+      expect(skippedTests).to.include('skip: use with Babel (test)');
+      expect(skippedTests).to.include('skip: use with Babel (it)');
+      expect(skippedTests).to.include('skip: %i file should exist (it.each)');
+      expect(skippedTests).to.include('skip: %i file should exist (test.each)');
 
-  //     expect(actualTests).to.have.lengthOf(4);
-  //     expect(skippedTests).to.have.lengthOf(4);
-  //   });
+      expect(actualTests).to.have.lengthOf(4);
+      expect(skippedTests).to.have.lengthOf(4);
+    });
 
-  //   it('should include code', () => {
-  //     const tests = jestParser(ast, '', source);
-  //     expect(tests[0]).to.include.key('code');
-  //     expect(tests[0].code).to.include("test('base'");
-  //   });
-  // });
+    it('should include code', () => {
+      const tests = jestParser(ast, '', source);
+      expect(tests[0]).to.include.key('code');
+      expect(tests[0].code).to.include("test('base'");
+    });
+  });
 
-  // context('exclusive tests', () => {
-  //   before(() => {
-  //     source = fs.readFileSync('./example/jest/vue.spec.only.js').toString();
-  //     ast = parser.parse(source);
-  //   });
+  context('exclusive tests', () => {
+    before(() => {
+      source = fs.readFileSync('./example/jest/vue.spec.only.js').toString();
+      ast = parser.parse(source);
+    });
 
-  //   it('should throw an error if a file contains .only', () => {
-  //     const parse = () => jestParser(ast);
+    it('should throw an error if a file contains .only', () => {
+      const parse = () => jestParser(ast);
 
-  //     expect(parse).to.throw(
-  //       'Exclusive tests detected. `.only` call found in ' + ':1\n' + 'Remove `.only` to restore test checks',
-  //     );
-  //   });
-  // });
+      expect(parse).to.throw(
+        'Exclusive tests detected. `.only` call found in ' + ':1\n' + 'Remove `.only` to restore test checks',
+      );
+    });
+  });
 
   context('hooks tests - default opts', () => {
     before(() => {

--- a/tests/jest_test.js
+++ b/tests/jest_test.js
@@ -7,51 +7,94 @@ let source;
 let ast;
 
 describe('jest parser', () => {
-  context('jest tests', () => {
+  // context('jest tests', () => {
+  //   before(() => {
+  //     source = fs.readFileSync('./example/jest/vue.spec.js').toString();
+  //     ast = parser.parse(source);
+  //   });
+
+  //   it('should parse jest file', () => {
+  //     const tests = jestParser(ast);
+
+  //     const actualTests = tests.filter(t => !t.skipped).map(t => t.name);
+  //     const skippedTests = tests.filter(t => t.skipped).map(t => t.name);
+
+  //     expect(actualTests).to.include('base');
+  //     expect(actualTests).to.include('history mode');
+  //     expect(actualTests).to.include('file should exist');
+  //     expect(actualTests).to.include('%i file should exist (it.each)');
+
+  //     expect(skippedTests).to.include('skip: use with Babel (test)');
+  //     expect(skippedTests).to.include('skip: use with Babel (it)');
+  //     expect(skippedTests).to.include('skip: %i file should exist (it.each)');
+  //     expect(skippedTests).to.include('skip: %i file should exist (test.each)');
+
+  //     expect(actualTests).to.have.lengthOf(4);
+  //     expect(skippedTests).to.have.lengthOf(4);
+  //   });
+
+  //   it('should include code', () => {
+  //     const tests = jestParser(ast, '', source);
+  //     expect(tests[0]).to.include.key('code');
+  //     expect(tests[0].code).to.include("test('base'");
+  //   });
+  // });
+
+  // context('exclusive tests', () => {
+  //   before(() => {
+  //     source = fs.readFileSync('./example/jest/vue.spec.only.js').toString();
+  //     ast = parser.parse(source);
+  //   });
+
+  //   it('should throw an error if a file contains .only', () => {
+  //     const parse = () => jestParser(ast);
+
+  //     expect(parse).to.throw(
+  //       'Exclusive tests detected. `.only` call found in ' + ':1\n' + 'Remove `.only` to restore test checks',
+  //     );
+  //   });
+  // });
+
+  context('hooks tests - default opts', () => {
     before(() => {
-      source = fs.readFileSync('./example/jest/vue.spec.js').toString();
+      source = fs.readFileSync('./example/jest/hooks.spec.js').toString();
       ast = parser.parse(source);
     });
 
-    it('should parse jest file', () => {
-      const tests = jestParser(ast);
-
-      const actualTests = tests.filter(t => !t.skipped).map(t => t.name);
-      const skippedTests = tests.filter(t => t.skipped).map(t => t.name);
-
-      expect(actualTests).to.include('base');
-      expect(actualTests).to.include('history mode');
-      expect(actualTests).to.include('file should exist');
-      expect(actualTests).to.include('%i file should exist (it.each)');
-
-      expect(skippedTests).to.include('skip: use with Babel (test)');
-      expect(skippedTests).to.include('skip: use with Babel (it)');
-      expect(skippedTests).to.include('skip: %i file should exist (it.each)');
-      expect(skippedTests).to.include('skip: %i file should exist (test.each)');
-
-      expect(actualTests).to.have.lengthOf(4);
-      expect(skippedTests).to.have.lengthOf(4);
-    });
-
-    it('should include code', () => {
+    it('should include beforeAll hook code', () => {
       const tests = jestParser(ast, '', source);
-      expect(tests[0]).to.include.key('code');
-      expect(tests[0].code).to.include("test('base'");
+      // first test
+      expect(tests[0].code).to.include("beforeAll(() => {\n");
+      expect(tests[0].code).to.include("console.log('Ran beforeAll');\n");
+      expect(tests[0].code).to.include("expect(foods[1]).toBeTruthy();\n");
+      // second test
+      expect(tests[1].code).to.include("beforeAll(() => {\n");
+      expect(tests[1].code).to.include("console.log('Ran beforeAll');\n");
+      expect(tests[1].code).to.include("expect(foods[1]).toBeTruthy();\n");
     });
-  });
 
-  context('exclusive tests', () => {
-    before(() => {
-      source = fs.readFileSync('./example/jest/vue.spec.only.js').toString();
-      ast = parser.parse(source);
+    it('should include beforeEach hook code', () => {
+      const tests = jestParser(ast, '', source);
+      // first test
+      expect(tests[0].code).to.include("beforeEach(() => {\n");
+      expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[0].code).to.include("expect(foods[2]).toBeTruthy();\n");
+      // second test
+      expect(tests[1].code).to.include("beforeEach(() => {\n");
+      expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[1].code).to.include("expect(foods[2]).toBeTruthy();\n");
     });
 
-    it('should throw an error if a file contains .only', () => {
-      const parse = () => jestParser(ast);
-
-      expect(parse).to.throw(
-        'Exclusive tests detected. `.only` call found in ' + ':1\n' + 'Remove `.only` to restore test checks',
-      );
+    it('should include afterAll hook code', () => {
+      const tests = jestParser(ast, '', source);
+      // first test
+      expect(tests[0].code).to.include("afterAll(() => {\n");
+      expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[0].code).to.include("expect(foods[0]).toBeTruthy();\n");
+      // second test
+      expect(tests[1].code).to.include("afterAll(() => {\n");
+      expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[1].code).to.include("expect(foods[0]).toBeTruthy();\n");
     });
   });
 });

--- a/tests/jest_test.js
+++ b/tests/jest_test.js
@@ -64,37 +64,70 @@ describe('jest parser', () => {
     it('should include beforeAll hook code', () => {
       const tests = jestParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("beforeAll(() => {\n");
+      expect(tests[0].code).to.include('beforeAll(() => {\n');
       expect(tests[0].code).to.include("console.log('Ran beforeAll');\n");
-      expect(tests[0].code).to.include("expect(foods[1]).toBeTruthy();\n");
+      expect(tests[0].code).to.include('expect(foods[1]).toBeTruthy();\n');
       // second test
-      expect(tests[1].code).to.include("beforeAll(() => {\n");
+      expect(tests[1].code).to.include('beforeAll(() => {\n');
       expect(tests[1].code).to.include("console.log('Ran beforeAll');\n");
-      expect(tests[1].code).to.include("expect(foods[1]).toBeTruthy();\n");
+      expect(tests[1].code).to.include('expect(foods[1]).toBeTruthy();\n');
     });
 
     it('should include beforeEach hook code', () => {
       const tests = jestParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("beforeEach(() => {\n");
+      expect(tests[0].code).to.include('beforeEach(() => {\n');
       expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
-      expect(tests[0].code).to.include("expect(foods[2]).toBeTruthy();\n");
+      expect(tests[0].code).to.include('expect(foods[2]).toBeTruthy();\n');
       // second test
-      expect(tests[1].code).to.include("beforeEach(() => {\n");
+      expect(tests[1].code).to.include('beforeEach(() => {\n');
       expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
-      expect(tests[1].code).to.include("expect(foods[2]).toBeTruthy();\n");
+      expect(tests[1].code).to.include('expect(foods[2]).toBeTruthy();\n');
     });
 
     it('should include afterAll hook code', () => {
       const tests = jestParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("afterAll(() => {\n");
+      expect(tests[0].code).to.include('afterAll(() => {\n');
       expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
-      expect(tests[0].code).to.include("expect(foods[0]).toBeTruthy();\n");
+      expect(tests[0].code).to.include('expect(foods[0]).toBeTruthy();\n');
       // second test
-      expect(tests[1].code).to.include("afterAll(() => {\n");
+      expect(tests[1].code).to.include('afterAll(() => {\n');
       expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
-      expect(tests[1].code).to.include("expect(foods[0]).toBeTruthy();\n");
+      expect(tests[1].code).to.include('expect(foods[0]).toBeTruthy();\n');
+    });
+  });
+
+  context('[with noHooks] hooks tests', () => {
+    let fileSource, fileAst;
+
+    before(() => {
+      fileSource = fs.readFileSync('./example/jest/hooks.spec.js').toString();
+      fileAst = parser.parse(source);
+    });
+
+    it('should exclude beforeAll hook code', () => {
+      const tests = jestParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('beforeAll(() => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('before(() => {\n');
+    });
+
+    it('should exclude beforeEach hook code', () => {
+      const tests = jestParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('beforeEach(() => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('beforeEach(() => {\n');
+    });
+
+    it('should exclude after hook code', () => {
+      const tests = jestParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('afterAll(() => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('afterAll(() => {\n');
     });
   });
 });

--- a/tests/mocha_test.js
+++ b/tests/mocha_test.js
@@ -76,11 +76,11 @@ describe('mocha parser', () => {
     it('should include before hook code by default', () => {
       const tests = mochaParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("before(() => {\n");
+      expect(tests[0].code).to.include('before(() => {\n');
       expect(tests[0].code).to.include("console.log('Ran before');\n");
       expect(tests[0].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
       // second test
-      expect(tests[1].code).to.include("before(() => {\n");
+      expect(tests[1].code).to.include('before(() => {\n');
       expect(tests[1].code).to.include("console.log('Ran before');\n");
       expect(tests[1].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
     });
@@ -88,11 +88,11 @@ describe('mocha parser', () => {
     it('should include beforeEach hook code by default', () => {
       const tests = mochaParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("beforeEach(() => {\n");
+      expect(tests[0].code).to.include('beforeEach(() => {\n');
       expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
       expect(tests[0].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
       // second test
-      expect(tests[1].code).to.include("beforeEach(() => {\n");
+      expect(tests[1].code).to.include('beforeEach(() => {\n');
       expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
       expect(tests[1].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
     });
@@ -100,13 +100,46 @@ describe('mocha parser', () => {
     it('should include after hook code by default', () => {
       const tests = mochaParser(ast, '', source);
       // first test
-      expect(tests[0].code).to.include("after(async () => {\n");
+      expect(tests[0].code).to.include('after(async () => {\n');
       expect(tests[0].code).to.include("console.log('Ran after');\n");
       expect(tests[0].code).to.include("cy.get('.action-disabled');\n");
       // second test
-      expect(tests[1].code).to.include("after(async () => {\n");
+      expect(tests[1].code).to.include('after(async () => {\n');
       expect(tests[1].code).to.include("console.log('Ran after');\n");
       expect(tests[1].code).to.include("cy.get('.action-disabled');\n");
+    });
+  });
+
+  context('[with noHooks] Cypress: hooks code', () => {
+    let fileSource, fileAst;
+
+    before(() => {
+      fileSource = fs.readFileSync('./example/mocha/cypress_hooks.spec.js').toString();
+      fileAst = parser.parse(source, { sourceType: 'unambiguous' });
+    });
+
+    it('should exclude before hook code', () => {
+      const tests = mochaParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('before(() => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('before(() => {\n');
+    });
+
+    it('should exclude beforeEach hook code', () => {
+      const tests = mochaParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('beforeEach(() => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('beforeEach(() => {\n');
+    });
+
+    it('should exclude after hook code', () => {
+      const tests = mochaParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('after(async () => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('after(async () => {\n');
     });
   });
 });

--- a/tests/mocha_test.js
+++ b/tests/mocha_test.js
@@ -66,4 +66,47 @@ describe('mocha parser', () => {
       // assert.equal(tests.length, 3);
     });
   });
+
+  context('Cypress: hooks tests', () => {
+    before(() => {
+      source = fs.readFileSync('./example/mocha/cypress_hooks.spec.js').toString();
+      ast = parser.parse(source, { sourceType: 'unambiguous' });
+    });
+
+    it('should include before hook code by default', () => {
+      const tests = mochaParser(ast, '', source);
+      // first test
+      expect(tests[0].code).to.include("before(() => {\n");
+      expect(tests[0].code).to.include("console.log('Ran before');\n");
+      expect(tests[0].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
+      // second test
+      expect(tests[1].code).to.include("before(() => {\n");
+      expect(tests[1].code).to.include("console.log('Ran before');\n");
+      expect(tests[1].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
+    });
+
+    it('should include beforeEach hook code by default', () => {
+      const tests = mochaParser(ast, '', source);
+      // first test
+      expect(tests[0].code).to.include("beforeEach(() => {\n");
+      expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[0].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
+      // second test
+      expect(tests[1].code).to.include("beforeEach(() => {\n");
+      expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[1].code).to.include("cy.visit('http://localhost:8080/commands/actions');\n");
+    });
+
+    it('should include after hook code by default', () => {
+      const tests = mochaParser(ast, '', source);
+      // first test
+      expect(tests[0].code).to.include("after(async () => {\n");
+      expect(tests[0].code).to.include("console.log('Ran after');\n");
+      expect(tests[0].code).to.include("cy.get('.action-disabled');\n");
+      // second test
+      expect(tests[1].code).to.include("after(async () => {\n");
+      expect(tests[1].code).to.include("console.log('Ran after');\n");
+      expect(tests[1].code).to.include("cy.get('.action-disabled');\n");
+    });
+  });
 });

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -157,81 +157,80 @@ describe('playwright parser', () => {
     expect(tests[7].skipped).to.be.true;
     expect(tests[8].skipped).to.be.false;
   });
+  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
+  // context('[with TESTOMATIO_IMPORT_WITHOUT_HOOKS env] Parse Playwright hooks code', () => {
+  //   let fileSource, fileAst;
+  //   before(() => {
+  //     fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
+  //     fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
+  //   });
 
-  context('[without TESTOMATIO-WITH-HOOKS env] Parse Playwright hooks code', () => {
+  //   it('should exclude beforeAll hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.not.include("test.beforeAll('run before', async () => {\n");
+  //     // second test
+  //     expect(tests[1].code).to.not.include("test.beforeAll('run before', async () => {\n");
+  //   });
+
+  //   it('should exclude beforeEach hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+  //     // second test
+  //     expect(tests[1].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+  //   });
+
+  //   it('should exclude afterAll hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.not.include('test.afterAll(async () => {\n');
+  //     // second test
+  //     expect(tests[1].code).to.not.include('test.afterAll(async () => {\n');
+  //   });
+  // });
+
+  context('Parse Playwright hooks code - default opts', () => {
     let fileSource, fileAst;
     before(() => {
       fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
       fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
     });
 
-    it('should exclude beforeAll hook code', () => {
+    it('should include beforeAll hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.not.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[0].code).to.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[0].code).to.include("console.log('Ran before');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnBeforeAll').click();\n");
       // second test
-      expect(tests[1].code).to.not.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[1].code).to.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[1].code).to.include("console.log('Ran before');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnBeforeAll').click();\n");
     });
 
-    it('should exclude beforeEach hook code', () => {
+    it('should include beforeEach hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+      expect(tests[0].code).to.include('test.beforeEach(async ({ page }) => {\n');
+      expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnBeforeEach').click();\n");
       // second test
-      expect(tests[1].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+      expect(tests[1].code).to.include('test.beforeEach(async ({ page }) => {\n');
+      expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnBeforeEach').click();\n");
     });
 
-    it('should exclude afterAll hook code', () => {
+    it('should include afterAll hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.not.include('test.afterAll(async () => {\n');
+      expect(tests[0].code).to.include('test.afterAll(async () => {\n');
+      expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnafterAll').click();\n");
       // second test
-      expect(tests[1].code).to.not.include('test.afterAll(async () => {\n');
+      expect(tests[1].code).to.include('test.afterAll(async () => {\n');
+      expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
     });
   });
-  //TODO: need SET "TESTOMATIO_WITH_HOOKS": "1" in test
-  // context('[with TESTOMATIO-WITH-HOOKS env] Parse Playwright hooks code', () => {
-  //   let fileSource,
-  //     fileAst;
-  //   before(() => {
-  //     fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
-  //     fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
-  //   });
-
-  //   it('should include beforeAll hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("test.beforeAll('run before', async () => {\n");
-  //     expect(tests[0].code).to.include("console.log('Ran before');\n");
-  //     expect(tests[0].code).to.include("await page.locator('#btnBeforeAll').click();\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("test.beforeAll('run before', async () => {\n");
-  //     expect(tests[1].code).to.include("console.log('Ran before');\n");
-  //     expect(tests[1].code).to.include("await page.locator('#btnBeforeAll').click();\n");
-  //   });
-
-  //   it('should include beforeEach hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("test.beforeEach(async ({ page }) => {\n");
-  //     expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
-  //     expect(tests[0].code).to.include("await page.locator('#btnBeforeEach').click();\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("test.beforeEach(async ({ page }) => {\n");
-  //     expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
-  //     expect(tests[1].code).to.include("await page.locator('#btnBeforeEach').click();\n");
-  //   });
-
-  //   it('should include afterAll hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.include("test.afterAll(async () => {\n");
-  //     expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
-  //     expect(tests[0].code).to.include("await page.locator('#btnafterAll').click();\n");
-  //     // second test
-  //     expect(tests[1].code).to.include("test.afterAll(async () => {\n");
-  //     expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
-  //     expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
-  //   });
-  // });
 });

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -158,48 +158,80 @@ describe('playwright parser', () => {
     expect(tests[8].skipped).to.be.false;
   });
 
-  context('Parse Playwright hooks code', () => {
-    let fileSource,
-      fileAst;
+  context('[without TESTOMATIO-WITH-HOOKS env] Parse Playwright hooks code', () => {
+    let fileSource, fileAst;
     before(() => {
       fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
       fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
     });
 
-    it('should include beforeAll hook code', () => {
+    it('should exclude beforeAll hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("test.beforeAll('run before', async () => {\n");
-      expect(tests[0].code).to.include("console.log('Ran before');\n");
-      expect(tests[0].code).to.include("await page.locator('#btnBeforeAll').click();\n");
-      // second test 
-      expect(tests[1].code).to.include("test.beforeAll('run before', async () => {\n");
-      expect(tests[1].code).to.include("console.log('Ran before');\n");
-      expect(tests[1].code).to.include("await page.locator('#btnBeforeAll').click();\n");
+      expect(tests[0].code).to.not.include("test.beforeAll('run before', async () => {\n");
+      // second test
+      expect(tests[1].code).to.not.include("test.beforeAll('run before', async () => {\n");
     });
 
-    it('should include beforeEach hook code', () => {
+    it('should exclude beforeEach hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("test.beforeEach(async ({ page }) => {\n");
-      expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
-      expect(tests[0].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+      expect(tests[0].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
       // second test
-      expect(tests[1].code).to.include("test.beforeEach(async ({ page }) => {\n");
-      expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
-      expect(tests[1].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+      expect(tests[1].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
     });
 
-    it('should include afterAll hook code', () => {
+    it('should exclude afterAll hook code', () => {
       const tests = playwrightParser(fileAst, '', fileSource);
       // first test
-      expect(tests[0].code).to.include("test.afterAll(async () => {\n");
-      expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
-      expect(tests[0].code).to.include("await page.locator('#btnafterAll').click();\n");
+      expect(tests[0].code).to.not.include('test.afterAll(async () => {\n');
       // second test
-      expect(tests[1].code).to.include("test.afterAll(async () => {\n");
-      expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
-      expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
+      expect(tests[1].code).to.not.include('test.afterAll(async () => {\n');
     });
   });
+  //TODO: need SET "TESTOMATIO_WITH_HOOKS": "1" in test
+  // context('[with TESTOMATIO-WITH-HOOKS env] Parse Playwright hooks code', () => {
+  //   let fileSource,
+  //     fileAst;
+  //   before(() => {
+  //     fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
+  //     fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
+  //   });
+
+  //   it('should include beforeAll hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("test.beforeAll('run before', async () => {\n");
+  //     expect(tests[0].code).to.include("console.log('Ran before');\n");
+  //     expect(tests[0].code).to.include("await page.locator('#btnBeforeAll').click();\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("test.beforeAll('run before', async () => {\n");
+  //     expect(tests[1].code).to.include("console.log('Ran before');\n");
+  //     expect(tests[1].code).to.include("await page.locator('#btnBeforeAll').click();\n");
+  //   });
+
+  //   it('should include beforeEach hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("test.beforeEach(async ({ page }) => {\n");
+  //     expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
+  //     expect(tests[0].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("test.beforeEach(async ({ page }) => {\n");
+  //     expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
+  //     expect(tests[1].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+  //   });
+
+  //   it('should include afterAll hook code', () => {
+  //     const tests = playwrightParser(fileAst, '', fileSource);
+  //     // first test
+  //     expect(tests[0].code).to.include("test.afterAll(async () => {\n");
+  //     expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
+  //     expect(tests[0].code).to.include("await page.locator('#btnafterAll').click();\n");
+  //     // second test
+  //     expect(tests[1].code).to.include("test.afterAll(async () => {\n");
+  //     expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
+  //     expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
+  //   });
+  // });
 });

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -157,4 +157,49 @@ describe('playwright parser', () => {
     expect(tests[7].skipped).to.be.true;
     expect(tests[8].skipped).to.be.false;
   });
+
+  context('Parse Playwright hooks code', () => {
+    let fileSource,
+      fileAst;
+    before(() => {
+      fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
+      fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
+    });
+
+    it('should include beforeAll hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[0].code).to.include("console.log('Ran before');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnBeforeAll').click();\n");
+      // second test 
+      expect(tests[1].code).to.include("test.beforeAll('run before', async () => {\n");
+      expect(tests[1].code).to.include("console.log('Ran before');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnBeforeAll').click();\n");
+    });
+
+    it('should include beforeEach hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include("test.beforeEach(async ({ page }) => {\n");
+      expect(tests[0].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+      // second test
+      expect(tests[1].code).to.include("test.beforeEach(async ({ page }) => {\n");
+      expect(tests[1].code).to.include("console.log('Ran beforeEach');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnBeforeEach').click();\n");
+    });
+
+    it('should include afterAll hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource);
+      // first test
+      expect(tests[0].code).to.include("test.afterAll(async () => {\n");
+      expect(tests[0].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[0].code).to.include("await page.locator('#btnafterAll').click();\n");
+      // second test
+      expect(tests[1].code).to.include("test.afterAll(async () => {\n");
+      expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
+      expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
+    });
+  });
 });

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -157,38 +157,6 @@ describe('playwright parser', () => {
     expect(tests[7].skipped).to.be.true;
     expect(tests[8].skipped).to.be.false;
   });
-  //TODO: need SET "TESTOMATIO_IMPORT_WITHOUT_HOOKS": "1" in test
-  // context('[with TESTOMATIO_IMPORT_WITHOUT_HOOKS env] Parse Playwright hooks code', () => {
-  //   let fileSource, fileAst;
-  //   before(() => {
-  //     fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
-  //     fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
-  //   });
-
-  //   it('should exclude beforeAll hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.not.include("test.beforeAll('run before', async () => {\n");
-  //     // second test
-  //     expect(tests[1].code).to.not.include("test.beforeAll('run before', async () => {\n");
-  //   });
-
-  //   it('should exclude beforeEach hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
-  //     // second test
-  //     expect(tests[1].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
-  //   });
-
-  //   it('should exclude afterAll hook code', () => {
-  //     const tests = playwrightParser(fileAst, '', fileSource);
-  //     // first test
-  //     expect(tests[0].code).to.not.include('test.afterAll(async () => {\n');
-  //     // second test
-  //     expect(tests[1].code).to.not.include('test.afterAll(async () => {\n');
-  //   });
-  // });
 
   context('Parse Playwright hooks code - default opts', () => {
     let fileSource, fileAst;
@@ -231,6 +199,38 @@ describe('playwright parser', () => {
       expect(tests[1].code).to.include('test.afterAll(async () => {\n');
       expect(tests[1].code).to.include("console.log('Ran afterAll');\n");
       expect(tests[1].code).to.include("await page.locator('#btnafterAll').click();\n");
+    });
+  });
+
+  context('[with noHooks] Parse Playwright hooks code', () => {
+    let fileSource, fileAst;
+    before(() => {
+      fileSource = fs.readFileSync('./example/playwright/hooks.js').toString();
+      fileAst = jsParser.parse(fileSource, { sourceType: 'unambiguous' });
+    });
+
+    it('should exclude beforeAll hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include("test.beforeAll('run before', async () => {\n");
+      // second test
+      expect(tests[1].code).to.not.include("test.beforeAll('run before', async () => {\n");
+    });
+
+    it('should exclude beforeEach hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('test.beforeEach(async ({ page }) => {\n');
+    });
+
+    it('should exclude afterAll hook code', () => {
+      const tests = playwrightParser(fileAst, '', fileSource, { noHooks: true });
+      // first test
+      expect(tests[0].code).to.not.include('test.afterAll(async () => {\n');
+      // second test
+      expect(tests[1].code).to.not.include('test.afterAll(async () => {\n');
     });
   });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -33,3 +33,12 @@ export type ImportTests = {
   // list of test data
   tests: Test[];
 };
+
+export type Analyzer = {
+  // name of a framework
+  framework: string;
+  // path to test dir
+  workDir?: string;
+  // options (as {noHooks: true})
+  opts?: object;
+};


### PR DESCRIPTION
I have added an extra option to add
- before(beforeAll)
- beforeEach
- after(AfterAll) 
hooks to the client (Testomatio) => code section
This option is currently only available for Codeceptjs & Playwright adapters.

To activate, you need to use the Node env -> **TESTOMATIO_WITH_HOOKS=1**
example:
command = `TESTOMATIO_URL=https://beta.testomat.io TESTOMATIO_WITH_HOOKS=1 TESTOMATIO=<key>npx check-tests@<version> CodeceptJS "**/*{.,_}{test,spec,cy}.js" --sync`

![Screenshot-1](https://github.com/testomatio/check-tests/assets/82405549/a7271a74-4646-4844-b283-552e2ef906a4)
