### PR TITLE
check-test - new "--line-numbers" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,9 +449,20 @@ By default, check-test sends the code of the test hooks to the "client": before,
 In the "Codes" section you can see all the additional "context" of the test (Testomat.io).
 
 To exclude hook code from a client test, use the --no-hooks option
+
 ```
 TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --no-hooks
 ```
+
+### Additional line number to the test code
+
+To include line number code from a client test, use --line-numbers option.
+_(By default Code section exclude "line number")_
+
+```
+TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --line-numbers
+```
+
 
 ## Import Parametrized Tests
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -42,11 +42,16 @@ program
   .option('--purge, --unsafe-clean-ids', 'Remove testomatio ids from test and suite without server verification')
   .option('--clean-ids', 'Remove testomatio ids from test and suite')
   .option('--no-hooks', 'Exclude test hooks code from the code on the client')
+  .option('--line-numbers', 'Adding an extra line number to each block of code')
   .action(async (framework, files, opts) => {
     opts.framework = framework;
     opts.pattern = files;
     const isPattern = checkPattern(files);
     const frameworkOpts = {};
+
+    if (opts.lineNumbers) {
+      frameworkOpts.lineNumbers = true;
+    }
 
     if (!opts.hooks) {
       frameworkOpts.noHooks = !opts.hooks;

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,14 +47,6 @@
         "pretty-quick": "^3.1.3"
       }
     },
-    "node_modules/@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@actions/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
@@ -10004,13 +9996,13 @@
       }
     },
     "aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
+      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
       "dev": true,
       "peer": true,
       "requires": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "array-buffer-byte-length": {
@@ -10189,13 +10181,13 @@
       }
     },
     "axobject-query": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
+      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
       "dev": true,
       "peer": true,
       "requires": {
-        "dequal": "^2.0.3"
+        "deep-equal": "^2.0.5"
       }
     },
     "babel-code-frame": {
@@ -11117,13 +11109,6 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
-    },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "peer": true
     },
     "diff": {
       "version": "5.0.0",
@@ -12289,6 +12274,13 @@
         }
       }
     },
+    "is-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
+      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
+      "dev": true,
+      "peer": true
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -12330,6 +12322,13 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-set": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
+      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
+      "dev": true,
+      "peer": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -12392,6 +12391,13 @@
         "is-invalid-path": "^0.1.0"
       }
     },
+    "is-weakmap": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
+      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
+      "dev": true,
+      "peer": true
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -12399,6 +12405,17 @@
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
+      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "isarray": {
@@ -12460,16 +12477,14 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsx-ast-utils": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.4.tgz",
-      "integrity": "sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
+      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
+        "array-includes": "^3.1.5",
+        "object.assign": "^4.1.3"
       }
     },
     "language-subtag-registry": {
@@ -12823,6 +12838,17 @@
       "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
+    "object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -12904,16 +12930,16 @@
       }
     },
     "optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
       "requires": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
         "levn": "^0.4.1",
         "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
       }
     },
     "p-limit": {
@@ -13382,23 +13408,14 @@
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "dev": true
     },
-    "stream-browserify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+    "stop-iteration-iterator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
+      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
       "dev": true,
+      "peer": true,
       "requires": {
-        "inherits": "~2.0.4",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.2.0"
+        "internal-slot": "^1.0.4"
       }
     },
     "stream-browserify": {
@@ -13797,6 +13814,19 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-collection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
+      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-weakmap": "^2.0.1",
+        "is-weakset": "^2.0.1"
+      }
+    },
     "which-typed-array": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
@@ -13810,6 +13840,11 @@
         "has-tostringtag": "^1.0.0",
         "is-typed-array": "^1.1.10"
       }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "scripts": {
     "check": "node -r dotenv/config bin/check.js",
     "run": "node -r dotenv/config index.js",
-    "test": "mocha tests/**_test.js",
+    "test": "mocha tests/update_fs_test.js",
     "lint": "eslint 'src/**/*.js' --fix",
     "pretty-quick": "pretty-quick --staged",
     "prepare": "husky install",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-tests",
-  "version": "0.8.17-beta-2",
+  "version": "0.8.17-beta-3",
   "description": "Static analysis for tests. Prints all tests in console and fails when exclusive or skipped tests found.",
   "keywords": [
     "testing",
@@ -68,7 +68,7 @@
   "scripts": {
     "check": "node -r dotenv/config bin/check.js",
     "run": "node -r dotenv/config index.js",
-    "test": "mocha tests/update_fs_test.js",
+    "test": "mocha tests/**_test.js",
     "lint": "eslint 'src/**/*.js' --fix",
     "pretty-quick": "pretty-quick --staged",
     "prepare": "husky install",

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -14,6 +14,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   let currentSuite = '';
   // hooks variables
   const noHooks = opts?.noHooks;
+  // line-numbers opt
+  const isLineNumber = opts?.lineNumbers;
+
   let beforeCode = '';
   let beforeSuiteCode = '';
   let afterSuiteCode = '';
@@ -26,10 +29,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
     afterSuiteCode = afterSuiteCode ?? '';
 
     code = noHooks
-      ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+      ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
       : beforeSuiteCode +
         beforeCode +
-        getCode(source, getLineNumber(path), getEndLineNumber(path)) +
+        getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
         afterSuiteCode
 
     if (hasStringOrTemplateArgument(path.container)) {
@@ -53,7 +56,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         suites: [currentSuite],
         updatePoint: getUpdatePoint(path.container),
         line: getLineNumber(path),
-        code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+        code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
         file,
       });
     }
@@ -68,11 +71,11 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'Before' })) {
-        beforeCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
+        beforeCode = getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'BeforeSuite' })) {
-        beforeSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
+        beforeSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'only' })) {
@@ -95,7 +98,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             suites: [currentSuite],
             updatePoint: getUpdatePoint(path.container),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             skipped: true,
             file,
           });
@@ -112,7 +115,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'AfterSuite' })) {
-        afterSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path));
+        afterSuiteCode = getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber);
 
         if (afterSuiteCode && !noHooks) {
           for (const test of tests) {

--- a/src/lib/frameworks/codeceptjs.js
+++ b/src/lib/frameworks/codeceptjs.js
@@ -30,10 +30,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
     code = noHooks
       ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
-      : beforeSuiteCode +
-        beforeCode +
-        getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
-        afterSuiteCode
+      : beforeSuiteCode
+        + beforeCode
+        + getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
+        + afterSuiteCode;
 
     if (hasStringOrTemplateArgument(path.container)) {
       const testName = getStringValue(path.container);
@@ -83,9 +83,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         if (['Scenario'].includes(name)) {
           const line = getLineNumber(path);
           throw new CommentError(
-            'Exclusive tests detected. `.only` call found in ' +
-              `${file}:${line}\n` +
-              'Remove `.only` to restore test checks',
+            'Exclusive tests detected. `.only` call found in '
+              + `${file}:${line}\n`
+              + 'Remove `.only` to restore test checks',
           );
         }
       }
@@ -128,9 +128,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
       if (path.isIdentifier({ name: 'tag' })) {
         if (
-          !path.parentPath.container ||
-          !path.parentPath.container.arguments ||
-          !path.parentPath.container.arguments[0]
+          !path.parentPath.container
+          || !path.parentPath.container.arguments
+          || !path.parentPath.container.arguments[0]
         ) {
           return;
         }

--- a/src/lib/frameworks/jasmine.js
+++ b/src/lib/frameworks/jasmine.js
@@ -36,18 +36,18 @@ module.exports = (ast, file = '', source = '') => {
       if (path.isIdentifier({ name: 'fdescribe' })) {
         const line = getLineNumber(path);
         throw new CommentError(
-          'Exclusive tests detected. `fdescribe` call found in ' +
-            `${file}:${line}\n` +
-            'Remove `fdescibe` to restore test checks',
+          'Exclusive tests detected. `fdescribe` call found in '
+            + `${file}:${line}\n`
+            + 'Remove `fdescibe` to restore test checks',
         );
       }
 
       if (path.isIdentifier({ name: 'fit' })) {
         const line = getLineNumber(path);
         throw new CommentError(
-          'Exclusive tests detected. `fit` call found in ' +
-            `${file}:${line}\n` +
-            'Remove `fit` to restore test checks',
+          'Exclusive tests detected. `fit` call found in '
+            + `${file}:${line}\n`
+            + 'Remove `fit` to restore test checks',
         );
       }
 

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -132,10 +132,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
-          : beforeEachCode +
-            beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
-            afterCode;
+          : beforeEachCode
+            + beforeCode
+            + getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
+            + afterCode;
 
         const testName = getStringValue(path.parent);
         tests.push({

--- a/src/lib/frameworks/jest.js
+++ b/src/lib/frameworks/jest.js
@@ -14,6 +14,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   let currentSuite = [];
   // hooks variables
   const noHooks = opts?.noHooks;
+  // line-numbers opt
+  const isLineNumber = opts?.lineNumbers;
+
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -31,15 +34,15 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'beforeAll' })) {
-        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'afterAll' })) {
-        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
 
         if (afterCode && !noHooks) {
           for (const test of tests) {
@@ -83,7 +86,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             name: testName,
             suites: currentSuite.map(s => getStringValue(s)),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -111,7 +114,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             name: testName,
             suites: currentSuite.map(s => getStringValue(s)),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -128,10 +131,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         afterCode = afterCode ?? '';
 
         code = noHooks
-          ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+          ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
           : beforeEachCode +
             beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path)) +
+            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
             afterCode;
 
         const testName = getStringValue(path.parent);
@@ -156,7 +159,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
           suites: currentSuite.map(s => getStringValue(s)),
           updatePoint: getUpdatePoint(path.parent),
           line: getLineNumber(currentPath),
-          code: getCode(source, getLineNumber(currentPath), getEndLineNumber(currentPath)),
+          code: getCode(source, getLineNumber(currentPath), getEndLineNumber(currentPath), isLineNumber),
           file,
           skipped: !!currentSuite.filter(s => s.skipped).length,
         });

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -14,6 +14,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   let currentSuite = [];
   // hooks variables
   const noHooks = opts?.noHooks;
+  // line-numbers opt
+  const isLineNumber = opts?.lineNumbers;
+
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -36,15 +39,15 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'before' })) {
-        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'after' })) {
-        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
 
         if (afterCode && !noHooks) {
           for (const test of tests) {
@@ -83,7 +86,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             suites: currentSuite.map(s => getStringValue(s)),
             updatePoint: getUpdatePoint(path.parent.container),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -107,7 +110,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
           suites: currentSuite.map(s => getStringValue(s)),
           updatePoint: getUpdatePoint(path.parent),
           line: getLineNumber(path),
-          code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+          code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
           skipped: true,
           file,
         });
@@ -125,10 +128,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         afterCode = afterCode ?? '';
 
         code = noHooks
-          ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+          ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
           : beforeEachCode +
             beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path)) +
+            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
             afterCode;
 
         tests.push({

--- a/src/lib/frameworks/mocha.js
+++ b/src/lib/frameworks/mocha.js
@@ -129,10 +129,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
-          : beforeEachCode +
-            beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
-            afterCode;
+          : beforeEachCode
+            + beforeCode
+            + getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
+            + afterCode;
 
         tests.push({
           name: testName,

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -70,9 +70,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         if (['describe', 'it', 'context', 'test'].includes(name)) {
           const line = getLineNumber(path);
           throw new CommentError(
-            'Exclusive tests detected. `.only` call found in ' +
-              `${file}:${line}\n` +
-              'Remove `.only` to restore test checks',
+            'Exclusive tests detected. `.only` call found in '
+              + `${file}:${line}\n`
+              + 'Remove `.only` to restore test checks',
           );
         }
       }
@@ -183,10 +183,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
         code = noHooks
           ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
-          : beforeEachCode +
-            beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
-            afterCode;
+          : beforeEachCode
+            + beforeCode
+            + getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
+            + afterCode;
 
         const testName = getStringValue(path.parent);
 

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -14,6 +14,9 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   let currentSuite = [];
   // hooks variables
   const noHooks = opts?.noHooks;
+  // line-numbers opt
+  const isLineNumber = opts?.lineNumbers;
+
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
@@ -32,15 +35,15 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
       }
 
       if (path.isIdentifier({ name: 'beforeAll' })) {
-        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'beforeEach' })) {
-        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        beforeEachCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
       }
 
       if (path.isIdentifier({ name: 'afterAll' })) {
-        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath));
+        afterCode = getCode(source, getLineNumber(path.parentPath), getEndLineNumber(path.parentPath), isLineNumber);
 
         if (afterCode && !noHooks) {
           for (const test of tests) {
@@ -93,7 +96,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
               .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
               .map(s => getStringValue(s)),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -129,7 +132,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
               .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
               .map(s => getStringValue(s)),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -162,7 +165,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
               .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
               .map(s => getStringValue(s)),
             line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path)),
+            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
             file,
             skipped: true,
           });
@@ -179,10 +182,10 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         afterCode = afterCode ?? '';
 
         code = noHooks
-          ? getCode(source, getLineNumber(path), getEndLineNumber(path))
+          ? getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber)
           : beforeEachCode +
             beforeCode +
-            getCode(source, getLineNumber(path), getEndLineNumber(path)) +
+            getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber) +
             afterCode;
 
         const testName = getStringValue(path.parent);
@@ -212,7 +215,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             .map(s => getStringValue(s)),
           updatePoint: getUpdatePoint(path.parent),
           line: getLineNumber(currentPath),
-          code: getCode(source, getLineNumber(currentPath), getEndLineNumber(currentPath)),
+          code: getCode(source, getLineNumber(currentPath), getEndLineNumber(currentPath), isLineNumber),
           file,
           skipped: !!currentSuite.filter(s => s.skipped).length,
         });

--- a/src/lib/frameworks/qunit.js
+++ b/src/lib/frameworks/qunit.js
@@ -33,9 +33,9 @@ module.exports = (ast, file = '', source = '') => {
         if (['describe', 'it', 'context', 'test'].includes(name)) {
           const line = getLineNumber(path);
           throw new CommentError(
-            'Exclusive tests detected. `.only` call found in ' +
-              `${file}:${line}\n` +
-              'Remove `.only` to restore test checks',
+            'Exclusive tests detected. `.only` call found in '
+              + `${file}:${line}\n`
+              + 'Remove `.only` to restore test checks',
           );
         }
       }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -79,13 +79,17 @@ function getEndLineNumber(path) {
   return line;
 }
 
-function getCode(source, start, end) {
+function getCode(source, start, end, isLineNumber = false) {
   if (!start || !end || !source) return '';
-  const lines = source.split('\n');
+  let lines = source.split('\n');
+
+  if (isLineNumber) {
+    lines = lines.map((line, index) => `${index + 1}: ${line}`);
+  }
 
   for (let i = start - 1; i < end; i++) {
     if (lines[i].trim().endsWith('})') || lines[i].trim().endsWith('});')) {
-      lines[i] += '\n';
+      lines[i] += '\n\n';
     }
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -87,13 +87,9 @@ function getCode(source, start, end, isLineNumber = false) {
     lines = lines.map((line, index) => `${index + 1}: ${line}`);
   }
 
-  for (let i = start - 1; i < end; i++) {
-    if (lines[i].trim().endsWith('})') || lines[i].trim().endsWith('});')) {
-      lines[i] += '\n\n';
-    }
-  }
+  const block = lines.slice(start - 1, end).join('\n') + '\n\n';
 
-  return lines.slice(start - 1, end).join('\n');
+  return block;
 }
 
 function parseComments(source) {

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -122,8 +122,7 @@ function replaceAtPoint(subject, replaceAt, replaceTo) {
   if (updateLine.includes('|')) {
     lines[replaceAt.line - 1] = updateLine.replace(' |', `${replaceTo} |`);
   } else {
-    lines[replaceAt.line - 1] =
-      updateLine.substring(0, replaceAt.column) + replaceTo + updateLine.substring(replaceAt.column);
+    lines[replaceAt.line - 1] = updateLine.substring(0, replaceAt.column) + replaceTo + updateLine.substring(replaceAt.column);
   }
   return lines.join('\n');
 }

--- a/tests/mocha_test.js
+++ b/tests/mocha_test.js
@@ -110,7 +110,7 @@ describe('mocha parser', () => {
     });
   });
 
-  context('[with noHooks] Cypress: hooks code', () => {
+  context('[opts.noHooks = true] Cypress: hooks code', () => {
     let fileSource, fileAst;
 
     before(() => {
@@ -140,6 +140,44 @@ describe('mocha parser', () => {
       expect(tests[0].code).to.not.include('after(async () => {\n');
       // second test
       expect(tests[1].code).to.not.include('after(async () => {\n');
+    });
+  });
+
+  context('Cypress: test with --line-numbers option', () => {
+    let fileSource, fileAst;
+
+    before(() => {
+      fileSource = fs.readFileSync('./example/mocha/cypress_hooks.spec.js').toString();
+      fileAst = parser.parse(source, { sourceType: 'unambiguous' });
+    });
+
+    it('[lineNumbers=true opts] each section should include line-number as part of code section', () => {
+      const tests = mochaParser(fileAst, '', fileSource, { lineNumbers: true });
+      // first test only
+      expect(tests[0].code).to.include("13:     it('.type() - type into a DOM element', () => {\n");
+      // by default hooks include line number too
+      expect(tests[0].code).to.include('4:     beforeEach(() => {\n');
+      expect(tests[0].code).to.include('8:     before(() => {\n');
+      expect(tests[0].code).to.include('24:     after(async () => {\n');
+      // second test
+      expect(tests[1].code).to.include("20:     it('.click() - click on a DOM element', () => {\n");
+    });
+
+    it('[no SET the lineNumbers opts] should exclude line-number', () => {
+      const tests = mochaParser(fileAst, '', fileSource);
+      // first test only
+      expect(tests[0].code).to.not.include("13:     it('.type() - type into a DOM element', () => {\n");
+      // no lines
+      expect(tests[0].code).to.include("it('.type() - type into a DOM element', () => {\n");
+    });
+
+    // multiple options
+    it('[noHooks=true + lineNumbers=true opts] line-number as part of code section', () => {
+      const tests = mochaParser(fileAst, '', fileSource, { lineNumbers: true, noHooks: true });
+      // first test only
+      expect(tests[0].code).to.include("13:     it('.type() - type into a DOM element', () => {\n");
+      // no includes hook code
+      expect(tests[0].code).to.not.include('8:     before(() => {\n');
     });
   });
 });

--- a/tests/update_fs_test.js
+++ b/tests/update_fs_test.js
@@ -45,7 +45,7 @@ const createTestFiles = folderName => {
 
 const cleanFiles = folderName => {
   const targetPath = path.join(__dirname, '..', folderName);
-  fs.rmdirSync(targetPath, { recursive: true, force: true });
+  fs.rmSync(targetPath, { recursive: true, force: true });
 };
 
 beforeEach(() => {


### PR DESCRIPTION
I have added a new option to the "check-test" => option('--line-numbers', 'Adding an extra line number to each block of code')

**Additional line number to the test code**

_To include line number code from a client test, use --line-numbers option.
(By default Code section exclude "line number")_

```
TESTOMATIO=11111111 npx check-tests CodeceptJS "**/*{.,_}{test,spec}.js" --line-numbers
```

![Screenshot-case-1](https://github.com/testomatio/check-tests/assets/82405549/404a7e06-af7b-473a-9b9f-b7764ed2ddad)
