### PR TITLE
Update updateIds functionality

### DIFF
--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -23,10 +23,8 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
   for (const testArr of testData) {
     if (!testArr.length) continue;
 
-    // getting the file name from the test
     const file = `${workDir}/${testArr[0].file}`;
     debug('Updating file: ', file);
-    //reading the file content
     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
 
     for (const testItem of testArr) {
@@ -37,19 +35,14 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         // set suit name with file name to avoid duplicates
         let suiteIndex = `${testItem.file.replace('\\', '/')}` + '#' + suite;
         debug('Suite index', suiteIndex);
-        // if suit name with file name is not exist, set it to the suite name only
         if (!testomatioMap.suites[suiteIndex]) {
           suiteIndex = suite;
         }
-        // replace all tags in the suite name
         const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
-        // if the suite name consists ID, we will find it
         const currentSuiteId = parseSuite(suiteIndex);
-        // parse presented ID from suite name
         const existingIds = suite.match(/@S[a-z0-9]+/gi) || [];
-        // find suite ID in the testomatioMap
         const mappedId = testomatioMap.suites[suiteIndex] || testomatioMap.suites[suiteWithoutTags];
-        // verify fod duplicate suite ID or the same test
+        // verify for duplicate suite ID or the same test
         if (
           currentSuiteId &&
           testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
@@ -77,21 +70,15 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
 
     for (const test of testArr) {
       if (opts.framework === 'playwright' && test.name === true) continue;
-      // find suite name can be nul
       const suite = test.suites[0] || '';
-      // replace backslashes with slashes
       const normalizedFile = test.file.replace(/\\/g, '/');
-      // replace all tags in the test name
       const normalizedName = test.name.replace(TAG_REGEX, '').trim();
-      // replace all tags in the suite name
       const normalizedSuite = suite.replace(TAG_REGEX, '').trim();
 
       // set test name with file name and suite to avoid duplicates
       let testIndex = `${normalizedFile}#${suite}#${test.name}`;
-      // if test name with file name and suite without tags
       let testWithoutTags = `${normalizedSuite}#${normalizedName}`;
 
-      // if test name with file name and suite is not exist, set it to the test name only
       if (!testomatioMap.tests[testIndex]) {
         testIndex = `${suite}#${test.name}`;
       }
@@ -101,11 +88,8 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         testWithoutTags = normalizedName;
       }
 
-      // parse presented ID from test name
       const currentTestId = parseTest(testIndex);
-      // find test ID in the testomatioMap
       const mappedId = testomatioMap.tests[testIndex] || testomatioMap.tests[testWithoutTags];
-      // verify for duplicate test ID or the same test
       const existingIds = test.name.match(/@T[a-z0-9]+/gi) || [];
 
       // verify for dublicate test ID or the same test

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -1,3 +1,119 @@
+// const fs = require('fs');
+// const debug = require('debug')('testomatio:update-ids');
+// const { replaceAtPoint, cleanAtPoint } = require('../lib/utils');
+// const { TAG_REGEX } = require('./constants');
+// const { parseTest, parseSuite, replaceSuiteTitle } = require('./helpers');
+
+// /**
+//  * Insert test ids (@T12345678) into test files
+//  * @param {*} testData array of arrays of test data;
+//  * the main array represents test files, nested arrays includes test data for each test
+//  * @param {*} testomatioMap mapping of test ids received from testomatio server
+//  * @param {*} workDir
+//  * @param {*} opts
+//  * @returns
+//  */
+// function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
+//   const files = [];
+//   let duplicateTests = 0;
+//   let duplicateSuites = 0;
+
+//   debug('Test data:', testData);
+
+//   for (const testArr of testData) {
+//     if (!testArr.length) continue;
+
+//     const file = `${workDir}/${testArr[0].file}`;
+//     debug('Updating file: ', file);
+//     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
+
+//     let suiteId = '';
+//     for (const testItem of testArr) {
+//       for (const suite of testItem.suites) {
+//         if (!suite) continue;
+
+//         debug('Updating suite: ', suite);
+
+//         let suiteIndex = `${testItem.file.replace('\\', '/')}` + '#' + suite;
+//         debug('testIndex', suiteIndex);
+
+//         if (!testomatioMap.suites[suiteIndex]) {
+//           suiteIndex = suite;
+//         }
+
+//         const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
+//         const currentSuiteId = parseSuite(suiteIndex);
+
+//         if (testomatioMap.suites[suiteIndex] === suiteId) continue;
+
+//         const existingIds = suite.match(/@S[a-z0-9]+/gi) || [];
+
+//         const mappedId = testomatioMap.suites[suiteIndex] || testomatioMap.suites[suiteWithoutTags];
+
+//         if (currentSuiteId && mappedId && existingIds.includes(mappedId)) {
+//           debug(`   Skipping duplicate for suite '${suiteIndex}'`);
+//           continue;
+//         }
+
+//         if (mappedId && !existingIds.includes(mappedId)) {
+//           const updatedSuite = `${suite} ${mappedId}`;
+//           fileContent = replaceSuiteTitle(suite, updatedSuite, fileContent);
+//           fs.writeFileSync(file, fileContent);
+
+//           suiteId = mappedId;
+//           delete testomatioMap.suites[suiteIndex];
+//           delete testomatioMap.suites[suiteWithoutTags];
+//         }
+//       }
+//     }
+
+//     for (const test of testArr) {
+//       if (opts.framework === 'playwright' && test.name === true) continue;
+
+//       const suite = test.suites[0] || '';
+//       const normalizedFile = test.file.replace(/\\/g, '/');
+//       const normalizedName = test.name.replace(TAG_REGEX, '').trim();
+//       const normalizedSuite = suite.replace(TAG_REGEX, '').trim();
+
+//       let testIndex = `${normalizedFile}#${suite}#${test.name}`;
+//       let testWithoutTags = `${normalizedSuite}#${normalizedName}`;
+
+//       if (!testomatioMap.tests[testIndex]) {
+//         testIndex = `${suite}#${test.name}`;
+//       }
+//       if (!testomatioMap.tests[testIndex] && !testomatioMap.tests[testWithoutTags]) {
+//         testIndex = test.name;
+//         testWithoutTags = normalizedName;
+//       }
+
+//       const currentTestId = parseTest(testIndex);
+//       const mappedId = testomatioMap.tests[testIndex] || testomatioMap.tests[testWithoutTags];
+//       const existingIds = test.name.match(/@T[a-z0-9]+/gi) || [];
+
+//       if (currentTestId && mappedId && existingIds.includes(mappedId)) {
+//         debug(`Previous ID detected in test '${testIndex}'`);
+//         duplicateTests++;
+//         continue;
+//       }
+
+//       if (mappedId && !existingIds.includes(mappedId)) {
+//         fileContent = replaceAtPoint(fileContent, test.updatePoint, ` ${mappedId}`);
+//         fs.writeFileSync(file, fileContent);
+//         delete testomatioMap.tests[testIndex];
+//         delete testomatioMap.tests[testWithoutTags];
+//       }
+//     }
+//     files.push(file);
+//   }
+//   if (duplicateSuites || duplicateTests) {
+//     console.log('! Previously set Test IDs detected, new IDs ignored');
+//     console.log('! Clean previously set Test IDs to override them');
+//     console.log('! Run script with DEBUG="testomatio:*" flag to get more info of affected tests ');
+//   }
+
+//   return files;
+// }
+
 const fs = require('fs');
 const debug = require('debug')('testomatio:update-ids');
 const { replaceAtPoint, cleanAtPoint } = require('../lib/utils');
@@ -27,7 +143,6 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
     debug('Updating file: ', file);
     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
 
-    let suiteId = '';
     for (const testItem of testArr) {
       for (const suite of testItem.suites) {
         if (!suite) continue;
@@ -44,12 +159,18 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
         const currentSuiteId = parseSuite(suiteIndex);
 
-        if (testomatioMap.suites[suiteIndex] === suiteId) continue;
-
         const existingIds = suite.match(/@S[a-z0-9]+/gi) || [];
 
         const mappedId = testomatioMap.suites[suiteIndex] || testomatioMap.suites[suiteWithoutTags];
-
+        if (
+          currentSuiteId &&
+          testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
+          testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
+        ) {
+          debug(`   Previous ID detected in suite '${suiteIndex}'`);
+          duplicateSuites++;
+          continue;
+        }
         if (currentSuiteId && mappedId && existingIds.includes(mappedId)) {
           debug(`   Skipping duplicate for suite '${suiteIndex}'`);
           continue;
@@ -59,8 +180,6 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
           const updatedSuite = `${suite} ${mappedId}`;
           fileContent = replaceSuiteTitle(suite, updatedSuite, fileContent);
           fs.writeFileSync(file, fileContent);
-
-          suiteId = mappedId;
           delete testomatioMap.suites[suiteIndex];
           delete testomatioMap.suites[suiteWithoutTags];
         }
@@ -89,8 +208,11 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
       const currentTestId = parseTest(testIndex);
       const mappedId = testomatioMap.tests[testIndex] || testomatioMap.tests[testWithoutTags];
       const existingIds = test.name.match(/@T[a-z0-9]+/gi) || [];
-
-      if (currentTestId && mappedId && existingIds.includes(mappedId)) {
+      if (
+        currentTestId &&
+        testomatioMap.tests[testIndex] !== `@T${currentTestId}` &&
+        testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
+      ) {
         debug(`Previous ID detected in test '${testIndex}'`);
         duplicateTests++;
         continue;

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -66,42 +66,6 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         }
       }
     }
-    // let suiteId = '';
-    // for (const testItem of testArr) {
-    //   for (const suite of testItem.suites) {
-    //     if (!suite) continue;
-
-    //     debug('Updating suite: ', suite);
-    //     let suiteIndex = `${testItem.file.replace('\\', '/')}#${suite || ''}`;
-    //     debug('testIndex', suiteIndex);
-    //     if (!testomatioMap.suites[suiteIndex]) {
-    //       suiteIndex = `${suite || ''}`; // if file is not found
-    //     }
-    //     const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
-    //     const currentSuiteId = parseSuite(suiteIndex);
-    //     if (testomatioMap.suites[suiteIndex] == suiteId) continue;
-    //     if (
-    //       currentSuiteId &&
-    //       testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
-    //       testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
-    //     ) {
-    //       debug(`   Previous ID detected in suite '${suiteIndex}'`);
-    //       duplicateSuites++;
-    //       continue;
-    //     }
-    //     if (testomatioMap.suites[suiteIndex] && !suite.includes(testomatioMap.suites[suiteIndex])) {
-    //       fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteIndex]}`, fileContent);
-    //       fs.writeFileSync(file, fileContent);
-    //       suiteId = testomatioMap.suites[suiteIndex];
-    //       delete testomatioMap.suites[suiteIndex];
-    //     } else if (testomatioMap.suites[suiteWithoutTags] && !suite.includes(testomatioMap.suites[suiteWithoutTags])) {
-    //       fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteWithoutTags]}`, fileContent);
-    //       fs.writeFileSync(file, fileContent);
-    //       suiteId = testomatioMap.suites[suiteWithoutTags];
-    //       delete testomatioMap.suites[suiteWithoutTags];
-    //     }
-    //   }
-    // }
 
     for (const test of testArr) {
       if (opts.framework === 'playwright' && test.name === true) continue;
@@ -139,47 +103,6 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         delete testomatioMap.tests[testWithoutTags];
       }
     }
-
-    // for (const test of testArr) {
-    //   let testIndex = `${test.file.replace('\\', '/')}#${test.suites[0] || ''}#${test.name}`;
-    //   debug('testIndex', testIndex);
-
-    //   // this is not test; its test.skip() annotation inside a test
-    //   if (opts.framework === 'playwright' && test.name === true) continue;
-
-    //   let testWithoutTags = `${(test.suites[0] || '').replace(TAG_REGEX, '').trim()}#${test.name.replace(
-    //     TAG_REGEX,
-    //     '',
-    //   )}`.trim();
-    //   if (!testomatioMap.tests[testIndex]) {
-    //     testIndex = `${test.suites[0] || ''}#${test.name}`; // if file is not found
-    //   }
-    //   if (!testomatioMap.tests[testIndex] && !testomatioMap.tests[testWithoutTags]) {
-    //     testIndex = test.name; // if no suite title provided
-    //     testWithoutTags = test.name.replace(TAG_REGEX, '').trim();
-    //   }
-
-    //   const currentTestId = parseTest(testIndex);
-    //   if (
-    //     currentTestId &&
-    //     testomatioMap.tests[testIndex] !== `@T${currentTestId}` &&
-    //     testomatioMap.tests[testWithoutTags] !== `@T${currentTestId}`
-    //   ) {
-    //     debug(`Previous ID detected in test '${testIndex}'`);
-    //     duplicateTests++;
-    //     continue;
-    //   }
-
-    //   if (testomatioMap.tests[testIndex] && !test.name.includes(testomatioMap.tests[testIndex])) {
-    //     fileContent = replaceAtPoint(fileContent, test.updatePoint, ` ${testomatioMap.tests[testIndex]}`);
-    //     fs.writeFileSync(file, fileContent);
-    //     delete testomatioMap.tests[testIndex];
-    //   } else if (testomatioMap.tests[testWithoutTags] && !test.name.includes(testomatioMap.tests[testWithoutTags])) {
-    //     fileContent = replaceAtPoint(fileContent, test.updatePoint, ` ${testomatioMap.tests[testWithoutTags]}`);
-    //     fs.writeFileSync(file, fileContent);
-    //     delete testomatioMap.tests[testWithoutTags];
-    //   }
-    // }
     files.push(file);
   }
   if (duplicateSuites || duplicateTests) {

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -28,8 +28,9 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
     let fileContent = fs.readFileSync(file, { encoding: 'utf8' });
 
     let suiteId = '';
-    for (const suites of testArr) {
-      for (const suite of suites.suites) {
+    for (const testItem of testArr) {
+      for (const suite of testItem.suites) {
+        if (!suite) continue;
         if (suite) {
           debug('Updating suite: ', suite);
           const suiteIndex = suite;
@@ -74,7 +75,9 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         TAG_REGEX,
         '',
       )}`.trim();
-
+      if (!testomatioMap.tests[testIndex]) {
+        testIndex = `${test.suites[0] || ''}#${test.name}`; // if file is not found
+      }
       if (!testomatioMap.tests[testIndex] && !testomatioMap.tests[testWithoutTags]) {
         testIndex = test.name; // if no suite title provided
         testWithoutTags = test.name.replace(TAG_REGEX, '').trim();
@@ -135,9 +138,10 @@ function cleanIdsCommon(testData, testomatioMap = {}, workDir, opts = { dangerou
 
     for (const suites of testArr) {
       for (const suite of suites.suites) {
+        if (!suite) continue;
         if (suite) {
           const suiteId = `@S${parseSuite(suite)}`;
-          debug('  clenaing suite: ', suite);
+          debug('  cleaning suite: ', suite);
 
           if (suiteIds.includes(suiteId) || (dangerous && suiteId)) {
             const newTitle = suite.slice().replace(suiteId, '').trim();
@@ -149,7 +153,7 @@ function cleanIdsCommon(testData, testomatioMap = {}, workDir, opts = { dangerou
 
     for (const test of testArr) {
       const testId = `@T${parseTest(test.name)}`;
-      debug('  clenaing test: ', test.name);
+      debug('  cleaning test: ', test.name);
 
       if (testIds.includes(testId) || (dangerous && testId)) {
         fileContent = cleanAtPoint(fileContent, test.updatePoint, testId);

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -36,7 +36,7 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         debug('Updating suite: ', suite);
         // set suit name with file name to avoid duplicates
         let suiteIndex = `${testItem.file.replace('\\', '/')}` + '#' + suite;
-        debug('testIndex', suiteIndex);
+        debug('Suite index', suiteIndex);
         // if suit name with file name is not exist, set it to the suite name only
         if (!testomatioMap.suites[suiteIndex]) {
           suiteIndex = suite;

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -31,35 +31,31 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
     for (const testItem of testArr) {
       for (const suite of testItem.suites) {
         if (!suite) continue;
-        if (suite) {
-          debug('Updating suite: ', suite);
-          const suiteIndex = suite;
-          const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
 
-          if (testomatioMap.suites[suiteIndex] == suiteId) continue;
-          if (testomatioMap.suites[suiteWithoutTags] == suiteId) continue;
-          const currentSuiteId = parseSuite(suiteIndex);
-          if (
-            currentSuiteId &&
-            testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
-            testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
-          ) {
-            debug(`   Previous ID detected in suite '${suiteIndex}'`);
-            duplicateSuites++;
-            continue;
-          }
-          if (testomatioMap.suites[suiteIndex] && !suite.includes(testomatioMap.suites[suiteIndex])) {
-            fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteIndex]}`, fileContent);
-            fs.writeFileSync(file, fileContent);
-            suiteId = testomatioMap.suites[suiteIndex];
-          } else if (
-            testomatioMap.suites[suiteWithoutTags] &&
-            !suite.includes(testomatioMap.suites[suiteWithoutTags])
-          ) {
-            fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteWithoutTags]}`, fileContent);
-            fs.writeFileSync(file, fileContent);
-            suiteId = testomatioMap.suites[suiteWithoutTags];
-          }
+        debug('Updating suite: ', suite);
+        const suiteIndex = suite;
+        const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
+
+        if (testomatioMap.suites[suiteIndex] == suiteId) continue;
+        if (testomatioMap.suites[suiteWithoutTags] == suiteId) continue;
+        const currentSuiteId = parseSuite(suiteIndex);
+        if (
+          currentSuiteId &&
+          testomatioMap.suites[suiteIndex] !== `@S${currentSuiteId}` &&
+          testomatioMap.suites[suiteWithoutTags] !== `@S${currentSuiteId}`
+        ) {
+          debug(`   Previous ID detected in suite '${suiteIndex}'`);
+          duplicateSuites++;
+          continue;
+        }
+        if (testomatioMap.suites[suiteIndex] && !suite.includes(testomatioMap.suites[suiteIndex])) {
+          fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteIndex]}`, fileContent);
+          fs.writeFileSync(file, fileContent);
+          suiteId = testomatioMap.suites[suiteIndex];
+        } else if (testomatioMap.suites[suiteWithoutTags] && !suite.includes(testomatioMap.suites[suiteWithoutTags])) {
+          fileContent = replaceSuiteTitle(suite, `${suite} ${testomatioMap.suites[suiteWithoutTags]}`, fileContent);
+          fs.writeFileSync(file, fileContent);
+          suiteId = testomatioMap.suites[suiteWithoutTags];
         }
       }
     }
@@ -139,14 +135,13 @@ function cleanIdsCommon(testData, testomatioMap = {}, workDir, opts = { dangerou
     for (const suites of testArr) {
       for (const suite of suites.suites) {
         if (!suite) continue;
-        if (suite) {
-          const suiteId = `@S${parseSuite(suite)}`;
-          debug('  cleaning suite: ', suite);
 
-          if (suiteIds.includes(suiteId) || (dangerous && suiteId)) {
-            const newTitle = suite.slice().replace(suiteId, '').trim();
-            fileContent = fileContent.replace(suite, newTitle);
-          }
+        const suiteId = `@S${parseSuite(suite)}`;
+        debug('  cleaning suite: ', suite);
+
+        if (suiteIds.includes(suiteId) || (dangerous && suiteId)) {
+          const newTitle = suite.slice().replace(suiteId, '').trim();
+          fileContent = fileContent.replace(suite, newTitle);
         }
       }
     }

--- a/src/updateIds/updateIds.js
+++ b/src/updateIds/updateIds.js
@@ -33,9 +33,12 @@ function updateIdsCommon(testData, testomatioMap, workDir, opts = {}) {
         if (!suite) continue;
 
         debug('Updating suite: ', suite);
-        const suiteIndex = suite;
+        let suiteIndex = `${testItem.file.replace('\\', '/')}#${suite || ''}`;
+        debug('testIndex', suiteIndex);
+        if (!testomatioMap.suites[suiteIndex]) {
+          suiteIndex = `${suite || ''}`; // if file is not found
+        }
         const suiteWithoutTags = suite.replace(TAG_REGEX, '').trim();
-
         if (testomatioMap.suites[suiteIndex] == suiteId) continue;
         if (testomatioMap.suites[suiteWithoutTags] == suiteId) continue;
         const currentSuiteId = parseSuite(suiteIndex);

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -109,7 +109,7 @@ describe('update ids', () => {
     });
 
     it('ignore duplicates for ids from server', () => {
-      const analyzer = new Analyzer('codeceptjs', 'virtual_dir');
+      const analyzer = new Analyzer('codeceptjs', 'virtual_dir2');
 
       const idMap = {
         tests: {
@@ -121,7 +121,7 @@ describe('update ids', () => {
       };
 
       fs.writeFileSync(
-        './virtual_dir/test.js',
+        './virtual_dir2/test.js',
         `
         Feature('simple suite @Sf3d245a7')
         
@@ -132,7 +132,7 @@ describe('update ids', () => {
 
       analyzer.analyze('test.js');
 
-      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir2');
 
       const updatedFile = fs.readFileSync('virtual_dir/test.js').toString();
       expect(updatedFile).to.include("Feature('simple suite @Sf3d245a7')");

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -109,7 +109,7 @@ describe('update ids', () => {
     });
 
     it('ignore duplicates for ids from server', () => {
-      const analyzer = new Analyzer('codeceptjs', 'virtual_dir2');
+      const analyzer = new Analyzer('codeceptjs', 'virtual_dir');
 
       const idMap = {
         tests: {
@@ -121,7 +121,7 @@ describe('update ids', () => {
       };
 
       fs.writeFileSync(
-        './virtual_dir2/test.js',
+        './virtual_dir/test.js',
         `
         Feature('simple suite @Sf3d245a7')
         
@@ -132,7 +132,7 @@ describe('update ids', () => {
 
       analyzer.analyze('test.js');
 
-      updateIds(analyzer.rawTests, idMap, 'virtual_dir2');
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
 
       const updatedFile = fs.readFileSync('virtual_dir/test.js').toString();
       expect(updatedFile).to.include("Feature('simple suite @Sf3d245a7')");

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -123,11 +123,11 @@ describe('update ids', () => {
       fs.writeFileSync(
         './virtual_dir/test.js',
         `
-          Feature('simple suite @Sf3d245a7')
-          
-          Scenario('simple test @T1d6a52b9', async (I, TodosPage) => {
-          })        
-          `,
+        Feature('simple suite @Sf3d245a7')
+        
+        Scenario('simple test @T1d6a52b9', async (I, TodosPage) => {
+        })        
+        `,
       );
 
       analyzer.analyze('test.js');
@@ -553,58 +553,75 @@ describe('update ids', () => {
       expect(updatedFile2).to.include("it('Create API test cases @T22233b0f'");
     });
 
-    // it('should update ids based on filename for suites with the same name in different files', () => {
-    //   const analyzer1 = new Analyzer('codeceptjs', 'virtual_dir');
-    //   const analyzer2 = new Analyzer('codeceptjs', 'virtual_dir');
+    it('should update ids based on filename for suites with included nested suites', () => {
+      const analyzer = new Analyzer('mocha', 'virtual_dir');
 
-    //   const idMap = {
-    //     tests: {
-    //       'virtual_dir\\test1.js#my suite#my test': '@T1d6a52b9',
-    //       'virtual_dir\\test2.js#my suite#my test': '@T2e7b63c0',
-    //     },
-    //     suites: {
-    //       'virtual_dir\\test1.js#my suite': '@Sf3d245a7',
-    //       'virtual_dir\\test2.js#my suite': '@Sf3d245a1',
-    //     },
-    //   };
+      const idMap = {
+        tests: {
+          'test_included.j#Simple included suite#1. First included test': '@T47c6e680',
+          'Simple included suite#1. First included test': '@T47c6e680',
+          '1. First included test': '@T47c6e680',
+          'test_included.j#Simple suite and default values#1. First test': '@T96cd1c70',
+          'Simple suite and default values#1. First test': '@T96cd1c70',
+          '1. First test': '@T96cd1c70',
+          'test_included.j#Simple included suite#2. Second included test': '@Tda299d22',
+          'Simple included suite#2. Second included test': '@Tda299d22',
+          '2. Second included test': '@Tda299d22',
+          'test_included.j#Simple suite and default values#2. Second test': '@T9c32c073',
+          'Simple suite and default values#2. Second test': '@T9c32c073',
+          '2. Second test': '@T9c32c073',
+          'test_included.j#Simple included suite#3. Third included test': '@T1ad7596b',
+          'Simple included suite#3. Third included test': '@T1ad7596b',
+          '3. Third included test': '@T1ad7596b',
+          'test_included.j#Simple suite and default values#3. Third test': '@T68f84b8e',
+          'Simple suite and default values#3. Third test': '@T68f84b8e',
+          '3. Third test': '@T68f84b8e',
+        },
+        suites: {
+          'test_included.js#Simple included suite': '@S4f1651cf',
+          'Simple included suite': '@S4f1651cf',
+          'test_included.js#Simple suite and default values': '@S0a0cd701',
+          'Simple suite and default values': '@S0a0cd701',
+        },
+      };
 
-    //   // Write test1.js
-    //   fs.writeFileSync(
-    //     './virtual_dir/test1.js',
-    //     `Feature('my suite')
-    //   Scenario('my test', async ({ I }) => {
-    //     I.doSomething();
-    //   });`,
-    //   );
+      // Write test1.js
+      fs.writeFileSync(
+        './virtual_dir/test_included.js',
+        `describe('Simple suite and default values', function () {
+            it('1. First test', function () {
+            });
+            it('2. Second test', function () {
+            });
+            it('3. Third test', function () {
+            });
+            describe('Simple included suite', function () {
+                it('1. First included test', function () {
+                });
+                it('2. Second included test', function () {
+                });
+                it('3. Third included test', function () {
+                });
+            });
+        });`,
+      );
 
-    //   // Write test2.js
-    //   fs.writeFileSync(
-    //     './virtual_dir/test2.js',
-    //     `Feature('my suite')
-    //   Scenario('my test', async ({ I }) => {
-    //     I.doSomething();
-    //   });`,
-    //   );
+      // Analyze both files
+      analyzer.analyze('test_included.js');
+      // Update IDs for both files
+      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
 
-    //   // Analyze both files
-    //   analyzer1.analyze('test1.js');
-    //   analyzer2.analyze('test2.js');
-
-    //   // Update IDs for both files
-    //   updateIds(analyzer1.rawTests, idMap, 'virtual_dir');
-    //   updateIds(analyzer2.rawTests, idMap, 'virtual_dir');
-
-    //   // Read and validate updated test1.js
-    //   const updatedFile1 = fs.readFileSync('virtual_dir/test1.js').toString();
-    //   const updatedFile2 = fs.readFileSync('virtual_dir/test2.js').toString();
-    //   expect(updatedFile1).to.include("Feature('my suite @Sf3d245a7')");
-    //   expect(updatedFile1).to.include("Scenario('my test @T1d6a52b9')");
-
-    //   // Read and validate updated test2.js
-    //   // const updatedFile2 = fs.readFileSync('virtual_dir/test2.js').toString();
-    //   expect(updatedFile2).to.include("Feature('my suite @Sf3d245a1')");
-    //   expect(updatedFile2).to.include("Scenario('my test @T2e7b63c0')");
-    // });
+      // Read and validate updated test1.js
+      const updatedFile1 = fs.readFileSync('virtual_dir/test_included.js').toString();
+      expect(updatedFile1).to.include("describe('Simple suite and default values @S0a0cd701'");
+      expect(updatedFile1).to.include("it('1. First test @T96cd1c70'");
+      expect(updatedFile1).to.include("it('2. Second test @T9c32c073'");
+      expect(updatedFile1).to.include("it('3. Third test @T68f84b8e'");
+      expect(updatedFile1).to.include("describe('Simple included suite @S4f1651cf'");
+      expect(updatedFile1).to.include("it('1. First included test @T47c6e680'");
+      expect(updatedFile1).to.include("it('2. Second included test @Tda299d22'");
+      expect(updatedFile1).to.include("it('3. Third included test @T1ad7596b'");
+    });
   });
 
   describe('clean-ids', () => {

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -459,26 +459,33 @@ describe('update ids', () => {
 
       const idMap = {
         tests: {
-          'simple suite#parent test#child test': '@T1d6a52b9',
+          'simple suite#child test': '@T1d6a52b9',
           'simple suite#parent test': '@T2e7b63c0',
+          'second suite#child test': '@Tfe7124c0',
+          'second suite#parent test': '@T4ce7sdc0',
         },
         suites: {
           'simple suite': '@Sf3d245a7',
+          'second suite': '@Sf3d245a1',
         },
       };
 
       fs.writeFileSync(
         './virtual_dir/test.js',
-        `
-          Feature('simple suite')
-          
+        `Feature('simple suite')
           Scenario('parent test', async ({ I }) => {
-            within('nested', () => {
-              Scenario('child test', async ({ I }) => {
-                I.doSomething();
-              });
-            });
-          })        
+            I.doSomething();
+          })
+          Scenario('child test', async ({ I }) => {
+            I.doSomething();
+          });
+        Feature('second suite')
+          Scenario('parent test', async ({ I }) => {
+            I.doSomething();
+          })
+          Scenario('child test', async ({ I }) => {
+            I.doSomething();
+          });
           `,
       );
 

--- a/tests/updateIds_test.js
+++ b/tests/updateIds_test.js
@@ -455,49 +455,156 @@ describe('update ids', () => {
     });
 
     it('should update nested scenarios', () => {
-      const analyzer = new Analyzer('codeceptjs', 'virtual_dir');
+      const analyzer1 = new Analyzer('mocha', 'virtual_dir');
+      const analyzer2 = new Analyzer('mocha', 'virtual_dir');
 
-      const idMap = {
+      const idMap1 = {
         tests: {
-          'simple suite#child test': '@T1d6a52b9',
-          'simple suite#parent test': '@T2e7b63c0',
-          'second suite#child test': '@Tfe7124c0',
-          'second suite#parent test': '@T4ce7sdc0',
+          'test1.js#Login API by username#Login API should give valid response': '@T2d6a52b9',
+          'test1.js#Create API test cases#Create API test cases': '@T9ca4cb86',
+          'test1.js#Delete API test cases#Create API test cases': '@T23322b0f',
         },
         suites: {
-          'simple suite': '@Sf3d245a7',
-          'second suite': '@Sf3d245a1',
+          'test1.js#Login API by username': '@Secf29ed4',
+          'test1.js#Create API test cases': '@S63dfea36',
+          'test1.js#Delete API test cases': '@S0e1abeb1',
         },
       };
 
+      const idMap2 = {
+        tests: {
+          'test2.js#Login API by username#Login API should give valid response': '@T1d6a52b8',
+          'test2.js#Create API test cases#Create API test cases': '@T7ca4cb35',
+          'test2.js#Delete API test cases#Create API test cases': '@T22233b0f',
+        },
+        suites: {
+          'test2.js#Login API by username': '@Secf29ed9',
+          'test2.js#Create API test cases': '@S63dfea38',
+          'test2.js#Delete API test cases': '@S0e1abeb3',
+        },
+      };
+
+      // Write test1.js
       fs.writeFileSync(
-        './virtual_dir/test.js',
-        `Feature('simple suite')
-          Scenario('parent test', async ({ I }) => {
-            I.doSomething();
-          })
-          Scenario('child test', async ({ I }) => {
-            I.doSomething();
+        './virtual_dir/test1.js',
+        `describe('Login API by username', () => {
+          it('Login API should give valid response', () => {
+            // TODO: Add test logic here
           });
-        Feature('second suite')
-          Scenario('parent test', async ({ I }) => {
-            I.doSomething();
-          })
-          Scenario('child test', async ({ I }) => {
-            I.doSomething();
+        });
+
+        describe('Create API test cases', () => {
+          it('Create API test cases', () => {
+            // TODO: Add test logic here
           });
-          `,
+        });
+
+        describe('Delete API test cases', () => {
+          it('Create API test cases', () => {
+            // TODO: Add test logic here
+          });
+        });
+      `,
       );
 
-      analyzer.analyze('test.js');
+      // Write test2.js
+      fs.writeFileSync(
+        './virtual_dir/test2.js',
+        `describe('Login API by username', () => {
+          it('Login API should give valid response', () => {
+            // TODO: Add test logic here
+          });
+        });
 
-      updateIds(analyzer.rawTests, idMap, 'virtual_dir');
+        describe('Create API test cases', () => {
+          it('Create API test cases', () => {
+            // TODO: Add test logic here
+          });
+        });
 
-      const updatedFile = fs.readFileSync('virtual_dir/test.js').toString();
-      expect(updatedFile).to.include("Feature('simple suite @Sf3d245a7')");
-      expect(updatedFile).to.include("Scenario('parent test @T2e7b63c0'");
-      expect(updatedFile).to.include("Scenario('child test @T1d6a52b9'");
+        describe('Delete API test cases', () => {
+          it('Create API test cases', () => {
+            // TODO: Add test logic here
+          });
+        });
+      `,
+      );
+
+      analyzer1.analyze('test1.js');
+      analyzer2.analyze('test2.js');
+
+      updateIds(analyzer1.rawTests, idMap1, 'virtual_dir');
+      updateIds(analyzer2.rawTests, idMap2, 'virtual_dir');
+
+      const updatedFile1 = fs.readFileSync('virtual_dir/test1.js').toString();
+      expect(updatedFile1).to.include("describe('Login API by username @Secf29ed4'");
+      expect(updatedFile1).to.include("it('Login API should give valid response @T2d6a52b9'");
+      expect(updatedFile1).to.include("describe('Create API test cases @S63dfea36'");
+      expect(updatedFile1).to.include("it('Create API test cases @T9ca4cb86'");
+      expect(updatedFile1).to.include("describe('Delete API test cases @S0e1abeb1'");
+      expect(updatedFile1).to.include("it('Create API test cases @T23322b0f'");
+
+      const updatedFile2 = fs.readFileSync('virtual_dir/test2.js').toString();
+      expect(updatedFile2).to.include("describe('Login API by username @Secf29ed9'");
+      expect(updatedFile2).to.include("it('Login API should give valid response @T1d6a52b8'");
+      expect(updatedFile2).to.include("describe('Create API test cases @S63dfea38'");
+      expect(updatedFile2).to.include("it('Create API test cases @T7ca4cb35'");
+      expect(updatedFile2).to.include("describe('Delete API test cases @S0e1abeb3'");
+      expect(updatedFile2).to.include("it('Create API test cases @T22233b0f'");
     });
+
+    // it('should update ids based on filename for suites with the same name in different files', () => {
+    //   const analyzer1 = new Analyzer('codeceptjs', 'virtual_dir');
+    //   const analyzer2 = new Analyzer('codeceptjs', 'virtual_dir');
+
+    //   const idMap = {
+    //     tests: {
+    //       'virtual_dir\\test1.js#my suite#my test': '@T1d6a52b9',
+    //       'virtual_dir\\test2.js#my suite#my test': '@T2e7b63c0',
+    //     },
+    //     suites: {
+    //       'virtual_dir\\test1.js#my suite': '@Sf3d245a7',
+    //       'virtual_dir\\test2.js#my suite': '@Sf3d245a1',
+    //     },
+    //   };
+
+    //   // Write test1.js
+    //   fs.writeFileSync(
+    //     './virtual_dir/test1.js',
+    //     `Feature('my suite')
+    //   Scenario('my test', async ({ I }) => {
+    //     I.doSomething();
+    //   });`,
+    //   );
+
+    //   // Write test2.js
+    //   fs.writeFileSync(
+    //     './virtual_dir/test2.js',
+    //     `Feature('my suite')
+    //   Scenario('my test', async ({ I }) => {
+    //     I.doSomething();
+    //   });`,
+    //   );
+
+    //   // Analyze both files
+    //   analyzer1.analyze('test1.js');
+    //   analyzer2.analyze('test2.js');
+
+    //   // Update IDs for both files
+    //   updateIds(analyzer1.rawTests, idMap, 'virtual_dir');
+    //   updateIds(analyzer2.rawTests, idMap, 'virtual_dir');
+
+    //   // Read and validate updated test1.js
+    //   const updatedFile1 = fs.readFileSync('virtual_dir/test1.js').toString();
+    //   const updatedFile2 = fs.readFileSync('virtual_dir/test2.js').toString();
+    //   expect(updatedFile1).to.include("Feature('my suite @Sf3d245a7')");
+    //   expect(updatedFile1).to.include("Scenario('my test @T1d6a52b9')");
+
+    //   // Read and validate updated test2.js
+    //   // const updatedFile2 = fs.readFileSync('virtual_dir/test2.js').toString();
+    //   expect(updatedFile2).to.include("Feature('my suite @Sf3d245a1')");
+    //   expect(updatedFile2).to.include("Scenario('my test @T2e7b63c0')");
+    // });
   });
 
   describe('clean-ids', () => {


### PR DESCRIPTION
Refactor the `updateIdsCommon` and `cleanIdsCommon` functions to improve suite ID handling and ensure more efficient updates to file content. This change enhances the logic for identifying and replacing suite titles based on the provided mapping.