### PR TITLE
fix(playwright): inherit tags from describe suites (#1236)

### DIFF
--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -8,6 +8,7 @@ const {
   getEndLineNumber,
   getCode,
   playwright,
+  getAllSuiteTags,
 } = require('../utils');
 
 module.exports = (ast, file = '', source = '', opts = {}) => {
@@ -24,6 +25,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
 
   function addSuite(path) {
     currentSuite = currentSuite.filter(s => s.loc.end.line > path.loc.start.line);
+    path.tags = playwright.getTestProps({ parent: { expression: path } }).tags;
     currentSuite.push(path);
   }
 
@@ -210,7 +212,7 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
             line: getLineNumber(path),
             code,
             file,
-            tags: playwright.getTestProps(path.parentPath).tags,
+            tags: [...getAllSuiteTags(currentSuite), ...playwright.getTestProps(path.parentPath).tags],
             annotations: playwright.getTestProps(path.parentPath).annotations,
             skipped: !!currentSuite.filter(s => s.skipped).length,
           });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -244,6 +244,16 @@ const jest = {
   },
 };
 
+function getAllSuiteTags(currentSuite) {
+  const tags = [];
+  currentSuite.forEach(suite => {
+    if (suite.tags && suite.tags.length) {
+      tags.push(...suite.tags);
+    }
+  });
+  return tags;
+}
+
 module.exports = {
   hasStringArgument,
   hasTemplateQuasi,
@@ -261,4 +271,5 @@ module.exports = {
   cleanAtPoint,
   playwright,
   arrayCompare,
+  getAllSuiteTags,
 };


### PR DESCRIPTION
This PR fixes Playwright test import so that tags defined on `test.describe` are inherited by inner tests and correctly displayed on the Tests page in Testomat.io.

https://github.com/testomatio/app/issues/1236

**Result**
- Tests inside a tagged test.describe are now imported with the expected tags and shown correctly on the Tests page.
- Users no longer have to duplicate tags on every individual Playwright test when they already tag the whole suite.