### PR TITLE
markdown. add sid to suite name

### DIFF
--- a/example/multi-suites.test.md
+++ b/example/multi-suites.test.md
@@ -1,0 +1,57 @@
+<!-- suite
+id: @Sf5ee38dj
+emoji:
+-->
+
+# Suite1
+
+<!-- test
+id: @T5e61dd1a
+priority: normal
+-->
+
+# Test1
+
+### Requirements
+
+Some reqs
+
+### Steps
+
+1. Step1
+2. Step2
+
+<!-- suite
+id: @Sf5ee34dj
+emoji:
+-->
+
+# Suite1 > Suite2
+
+<!-- test
+id: @T2a4a986d
+priority: normal
+-->
+
+# Test2
+
+### Requirements
+
+Skip
+
+<!-- suite
+emoji:
+-->
+
+# Suite3
+
+<!-- test
+id: @T2a4a916d
+priority: normal
+-->
+
+# Test3
+
+### Requirements
+
+Skip

--- a/src/lib/frameworks/markdown.js
+++ b/src/lib/frameworks/markdown.js
@@ -24,8 +24,10 @@ module.exports = (ast, file = '', source = '') => {
       while (i < lines.length && !lines[i].trim()) i++;
       if (i < lines.length && lines[i].trim().startsWith('#')) {
         const suiteName = lines[i].trim().replace(/^#+\s*/, '');
+        const suiteId = suiteMetadata.data?.id;
+
         currentSuite = {
-          name: suiteName,
+          name: suiteId ? `${suiteName} ${suiteId}` : suiteName,
           line: i + 1,
           metadata: suiteMetadata.data,
         };

--- a/tests/manual_test.js
+++ b/tests/manual_test.js
@@ -58,4 +58,37 @@ describe('manual (markdown) parser', () => {
       });
     });
   });
+
+  context('markdown multiple-suites', () => {
+    before(() => {
+      source = fs.readFileSync('./example/multi-suites.test.md').toString();
+    });
+
+    it('should parse markdown file with multiple suites', () => {
+      const tests = markdownParser(null, 'multi-suites.test.md', source);
+
+      expect(tests).to.have.length.greaterThan(0);
+
+      const testNames = tests.map(t => t.name);
+      expect(testNames).to.include('Test1');
+      expect(testNames).to.include('Test2');
+      expect(testNames).to.include('Test3');
+    });
+
+    it('should extract all suites information', () => {
+      const tests = markdownParser(null, 'multi-suites.test.md', source);
+
+      // Suite with suite id in meta
+      const firstTest = tests[0];
+      expect(firstTest.suites).to.include('Suite1 @Sf5ee38dj');
+
+      // Nested suite names should be parsed correctly
+      const secondTest = tests[1];
+      expect(secondTest.suites).to.include('Suite1 > Suite2 @Sf5ee34dj');
+
+      // Suite without suite id in meta
+      const thirdTest = tests[2];
+      expect(thirdTest.suites).to.include('Suite3');
+    });
+  });
 });


### PR DESCRIPTION
## **User description**
**Added**:
 - Suite id from suite metadata to suite name if suite id presents. This allows us to more accurately synchronize test suites in the backend. For example it fixes bug with suites duplication on import if suite title differs locally and in backend.
 - Cover this logic with tests + added tests for markdown with multiple suites
 
 Related bug: https://github.com/testomatio/testomatio/issues/7755


___

## **CodeAnt-AI Description**
Show suite ID in suite name and parse multiple suites from markdown

### What Changed
- When a suite has an id in its metadata, the parser appends that id to the suite name visible in parsed tests (e.g., "Suite1 @Sf5ee38dj")
- Parser now recognizes and extracts multiple suites from a single markdown file, including nested suite names (e.g., "Suite1 > Suite2 @Sf5ee34dj")
- Added tests that verify multi-suite parsing and correct line numbers for parsed tests

### Impact
`✅ Fewer duplicated suites on import`
`✅ Clearer suite identification during sync/import`
`✅ Accurate parsing of nested and multiple suites`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
