### PR TITLE
fix: playwright suite parsing error

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -134,7 +134,13 @@ function cleanAtPoint(subject, replaceAt, cleanSubject) {
 const playwright = {
   getTestProps: path => {
     const testProps = { annotations: [], tags: [] };
-    const argumentsList = path.parent.expression.arguments;
+    let argumentsList = [];
+    if (path.node && path.node.arguments) {
+      argumentsList = path.node.arguments;
+    } else if (path.parent && path.parent.expression && path.parent.expression.arguments) {
+      argumentsList = path.parent.expression.arguments;
+    }
+
     if (!argumentsList?.length) return testProps;
     const argumentsWithTags = argumentsList.filter(arg => arg.type === 'ObjectExpression');
     if (!argumentsWithTags.length) return testProps;

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -504,4 +504,26 @@ test.describe.only('my test', () => {
 
     expect(tests.length).to.equal(1);
   });
+
+  it('should not crash when test is assigned to a variable or inside an array (regression for issue #1)', () => {
+    const source = `
+      // This works normally
+      test('works', () => {});
+
+      // This might fail if getTestProps relies on ExpressionStatement
+      const t = test('fails?', () => {});
+      
+      // Or inside a block not being an expression statement?
+      [test('in array', () => {})];
+    `;
+
+    ast = jsParser.parse(source, { sourceType: 'unambiguous', plugins: ['typescript'] });
+
+    // Should not throw
+    const tests = playwrightParser(ast, '', source);
+
+    expect(tests).to.be.an('array');
+    expect(tests.length).to.be.greaterThan(0);
+    expect(tests[0].name).to.equal('works');
+  });
 });


### PR DESCRIPTION
## **User description**
https://github.com/testomatio/check-tests/issues/243


___

## **CodeAnt-AI Description**
**Fix Playwright parser crash for tests assigned to variables or used in arrays**

### What Changed
- Parser no longer crashes when a test call is assigned to a variable or used inside an array or other non-expression-statement contexts; these tests are safely scanned instead of causing an error.
- Test coverage added that verifies parsing does not throw for mixed test declaration forms and that at least the normal test entries are returned.
- Playwright test property extraction now checks multiple node locations for arguments before giving up, preventing false negatives for tags/annotations.

### Impact
`✅ Fewer parser crashes when scanning Playwright suites`
`✅ Fewer CI test-parsing failures`
`✅ Clearer parsing for tests declared in variables or arrays`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
