### PR TITLE
fix: Reporter.attachFiles resolve file paths relative to workDir when -d option is used

### DIFF
--- a/bin/check.js
+++ b/bin/check.js
@@ -99,7 +99,7 @@ async function mainAction(framework, files, opts) {
           .catch(err => console.log('Error in creating test document', err));
       }
       if (apiKey) {
-        const reporter = new Reporter(apiKey.trim(), framework);
+        const reporter = new Reporter(apiKey.trim(), framework, workDir);
         reporter.addTests(decorator.getTests());
         const resp = reporter.send({
           sync: opts.sync || opts.updateIds,

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -6,7 +6,7 @@ const path = require('path');
 const fs = require('fs');
 
 class Reporter {
-  constructor(apiKey, framework) {
+  constructor(apiKey, framework, workDir) {
     if (!framework) {
       console.error('Framework cannot be empty');
     }
@@ -15,6 +15,7 @@ class Reporter {
     }
     this.apiKey = apiKey;
     this.framework = framework;
+    this.workDir = workDir || process.cwd();
     this.tests = [];
     this.files = {};
   }
@@ -30,7 +31,7 @@ class Reporter {
 
     for (const fileName of uniqueFiles) {
       try {
-        this.files[fileName] = fs.readFileSync(path.resolve(fileName), 'utf8');
+        this.files[fileName] = fs.readFileSync(path.resolve(this.workDir, fileName), 'utf8');
       } catch (err) {
         debug(`Error reading file ${fileName}: ${err.message}`);
       }

--- a/tests/reporter_test.js
+++ b/tests/reporter_test.js
@@ -303,6 +303,47 @@ describe('Reporter', () => {
       expect(reporter.files['./example/checkout.test.md']).to.be.a('string');
       expect(reporter.files['./example/checkout.test.md']).to.include('# Checkout Process');
     });
+
+    it('should resolve file paths relative to workDir when workDir is passed to constructor', () => {
+      // test method behaviour with -d option. Analyzer sets 'file' field relative to workDir. So attachFiles should use workDir as relative path to file
+      const reporterWithWorkDir = new Reporter(mockApiKey, mockFramework, 'example');
+      const tests = [
+        {
+          name: 'Test 1',
+          file: 'checkout.test.md',
+          suites: ['Suite 1'],
+        },
+        {
+          name: 'Test 2',
+          file: 'test-specification.md',
+          suites: ['Suite 2'],
+        },
+      ];
+
+      reporterWithWorkDir.addTests(tests);
+      reporterWithWorkDir.attachFiles();
+
+      expect(reporterWithWorkDir.files).to.have.property('checkout.test.md');
+      expect(reporterWithWorkDir.files).to.have.property('test-specification.md');
+      expect(reporterWithWorkDir.files['checkout.test.md']).to.be.a('string');
+      expect(reporterWithWorkDir.files['checkout.test.md']).to.include('# Checkout Process');
+    });
+
+    it('should not find files when workDir is wrong and paths are relative to a different dir', () => {
+      // Without workDir, 'checkout.test.md' resolves relative to cwd — file does not exist there
+      const tests = [
+        {
+          name: 'Test 1',
+          file: 'checkout.test.md',
+          suites: ['Suite 1'],
+        },
+      ];
+
+      reporter.addTests(tests);
+      reporter.attachFiles();
+
+      expect(reporter.files).to.not.have.property('checkout.test.md');
+    });
   });
 
   describe('send method integration', () => {


### PR DESCRIPTION
**Reporter.attachFiles** method should resolve file path according to passed **workDir** when **-d** option is used. **Analyzer** set test.file field relative to given **workDir** or **process.cwd()**, so **attachFiles** method should also use this logic, to be able to find files when **workDir** is set.

Ticket: https://github.com/testomatio/app/issues/1568

