### PR TITLE
chunk uploads for large test syncs

### DIFF
--- a/src/reporter.js
+++ b/src/reporter.js
@@ -18,6 +18,9 @@ class Reporter {
     this.workDir = workDir || process.cwd();
     this.tests = [];
     this.files = {};
+    this.maxChunkBytes = 1 * 1024 * 1024;
+    this.maxChunkFiles = 100;
+    this.maxChunkTests = 500;
   }
 
   addTests(tests) {
@@ -122,41 +125,209 @@ class Reporter {
     });
   }
 
-  send(opts = {}) {
+  async send(opts = {}) {
+    console.log('\n 🚀 Sending data to testomat.io\n');
+
+    this.tests = this.prepareTests();
+    const payloadOpts = this.buildUploadOptions(opts);
+    this.attachFiles();
+
+    const chunks = this.createUploadChunks(payloadOpts);
+    if (chunks.length > 1) {
+      await this.sendInChunks(payloadOpts, chunks);
+      return;
+    }
+
+    const data = this.buildPayload(payloadOpts, this.tests, this.files);
+    await this.sendRequest(data);
+  }
+
+  prepareTests() {
+    const labelsFromEnv = this.parseLabels(process.env.TESTOMATIO_LABELS || process.env.TESTOMATIO_SYNC_LABELS);
+
+    return this.tests.map(test => {
+      const nextTest = { ...test };
+
+      if (process.env.TESTOMATIO_WORKDIR && nextTest.file) {
+        const workdir = path.resolve(process.env.TESTOMATIO_WORKDIR);
+        const absoluteTestPath = path.resolve(nextTest.file);
+        nextTest.file = path.relative(workdir, absoluteTestPath);
+      }
+
+      nextTest.file = nextTest.file?.replace(/\\/g, '/');
+
+      if (labelsFromEnv.length > 0) {
+        nextTest.labels = labelsFromEnv;
+      }
+
+      return nextTest;
+    });
+  }
+
+  buildUploadOptions(opts = {}) {
+    const nextOpts = { ...opts };
+
+    if (process.env.TESTOMATIO_PREPEND_DIR) nextOpts.dir = process.env.TESTOMATIO_PREPEND_DIR;
+    if (process.env.TESTOMATIO_SUITE) nextOpts.suite = process.env.TESTOMATIO_SUITE;
+
+    return nextOpts;
+  }
+
+  buildPayload(opts = {}, tests = this.tests, files = this.files, extra = {}) {
+    return JSON.stringify({ ...opts, ...extra, tests, framework: this.framework, files });
+  }
+
+  createUploadChunks(opts = {}) {
+    if (this.tests.length === 0) {
+      return [{ tests: this.tests, files: this.files }];
+    }
+
+    const groups = this.groupTestsByFile();
+    const chunks = [];
+    let currentChunk = { tests: [], files: {} };
+
+    for (const group of groups) {
+      const groupChunks = this.splitOversizedGroup(group, opts);
+
+      for (const groupChunk of groupChunks) {
+        const nextChunk = {
+          tests: currentChunk.tests.concat(groupChunk.tests),
+          files: { ...currentChunk.files, ...groupChunk.files },
+        };
+        const nextChunkFilesCount = Object.keys(nextChunk.files).length;
+        const nextChunkTestsCount = nextChunk.tests.length;
+
+        if (
+          currentChunk.tests.length > 0 &&
+          (this.getPayloadSize(opts, nextChunk.tests, nextChunk.files) > this.maxChunkBytes ||
+            nextChunkFilesCount > this.maxChunkFiles ||
+            nextChunkTestsCount > this.maxChunkTests)
+        ) {
+          chunks.push(currentChunk);
+          currentChunk = groupChunk;
+          continue;
+        }
+
+        currentChunk = nextChunk;
+      }
+    }
+
+    if (currentChunk.tests.length > 0 || Object.keys(currentChunk.files).length > 0 || chunks.length === 0) {
+      chunks.push(currentChunk);
+    }
+
+    return chunks;
+  }
+
+  groupTestsByFile() {
+    const groups = [];
+    const fileGroups = new Map();
+
+    this.tests.forEach((test, index) => {
+      const key = test.file || `__no_file__${index}`;
+
+      if (!fileGroups.has(key)) {
+        const group = {
+          tests: [],
+          files: test.file && this.files[test.file] !== undefined ? { [test.file]: this.files[test.file] } : {},
+        };
+        fileGroups.set(key, group);
+        groups.push(group);
+      }
+
+      fileGroups.get(key).tests.push(test);
+    });
+
+    return groups;
+  }
+
+  splitOversizedGroup(group, opts = {}) {
+    if (
+      (this.getPayloadSize(opts, group.tests, group.files) <= this.maxChunkBytes &&
+        group.tests.length <= this.maxChunkTests) ||
+      group.tests.length <= 1
+    ) {
+      return [group];
+    }
+
+    const splitGroups = [];
+    let currentGroup = { tests: [], files: group.files };
+
+    for (const test of group.tests) {
+      const nextGroup = {
+        tests: currentGroup.tests.concat(test),
+        files: group.files,
+      };
+
+      if (
+        currentGroup.tests.length > 0 &&
+        (this.getPayloadSize(opts, nextGroup.tests, nextGroup.files) > this.maxChunkBytes ||
+          nextGroup.tests.length > this.maxChunkTests)
+      ) {
+        splitGroups.push(currentGroup);
+        currentGroup = {
+          tests: [test],
+          files: group.files,
+        };
+        continue;
+      }
+
+      currentGroup = nextGroup;
+    }
+
+    if (currentGroup.tests.length > 0) {
+      splitGroups.push(currentGroup);
+    }
+
+    return splitGroups;
+  }
+
+  getPayloadSize(opts = {}, tests = this.tests, files = this.files, extra = {}) {
+    return Buffer.byteLength(this.buildPayload(opts, tests, files, extra));
+  }
+
+  async sendInChunks(opts, chunks) {
+    let importId;
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index];
+      const extra = {
+        chunk_upload: true,
+        finish: index === chunks.length - 1,
+      };
+
+      if (importId) extra.import_id = importId;
+
+      const response = await this.sendRequest(this.buildPayload(opts, chunk.tests, chunk.files, extra));
+
+      if (response.statusCode >= 400) {
+        throw new Error(response.body || `Chunk upload failed (${response.statusCode}: ${response.statusMessage})`);
+      }
+
+      if (index === 0) {
+        importId = this.extractImportId(response.body);
+        if (!importId && chunks.length > 1) {
+          throw new Error('Chunk upload failed: import_id was not returned after the first chunk');
+        }
+      }
+    }
+  }
+
+  extractImportId(message) {
+    if (!message) return null;
+
+    try {
+      const parsed = JSON.parse(message);
+      return parsed.import_id || null;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  sendRequest(data) {
+    debug('Sending test data to Testomat.io', data);
+
     return new Promise((resolve, reject) => {
-      console.log('\n 🚀 Sending data to testomat.io\n');
-
-      // Parse labels from environment variable (supports both TESTOMATIO_LABELS and TESTOMATIO_SYNC_LABELS)
-      const labelsFromEnv = this.parseLabels(process.env.TESTOMATIO_LABELS || process.env.TESTOMATIO_SYNC_LABELS);
-
-      const tests = this.tests.map(test => {
-        // make file path relative to TESTOMATIO_WORKDIR if provided
-        if (process.env.TESTOMATIO_WORKDIR && test.file) {
-          const workdir = path.resolve(process.env.TESTOMATIO_WORKDIR);
-          const absoluteTestPath = path.resolve(test.file);
-          test.file = path.relative(workdir, absoluteTestPath);
-        }
-
-        // unify path to use slashes (prevent backslashes on windows)
-        test.file = test.file?.replace(/\\/g, '/');
-
-        // Apply labels to each test
-        if (labelsFromEnv.length > 0) {
-          test.labels = labelsFromEnv;
-        }
-
-        return test;
-      });
-      this.tests = tests;
-
-      if (process.env.TESTOMATIO_PREPEND_DIR) opts.dir = process.env.TESTOMATIO_PREPEND_DIR;
-      if (process.env.TESTOMATIO_SUITE) opts.suite = process.env.TESTOMATIO_SUITE;
-
-      this.attachFiles();
-
-      const data = JSON.stringify({ ...opts, tests: this.tests, framework: this.framework, files: this.files });
-
-      debug('Sending test data to Testomat.io', data);
       const req = request(
         `${URL.trim()}/api/load?api_key=${this.apiKey}`,
         {
@@ -176,7 +347,12 @@ class Reporter {
             } else {
               console.log(' 🎉 Data received at Testomat.io');
             }
-            resolve();
+
+            resolve({
+              statusCode: resp.statusCode,
+              statusMessage: resp.statusMessage,
+              body: message,
+            });
           });
 
           resp.on('data', chunk => {

--- a/tests/reporter_test.js
+++ b/tests/reporter_test.js
@@ -620,6 +620,273 @@ describe('Reporter', () => {
       });
     });
 
+    describe('chunked upload', () => {
+      it('should split upload by payload size and pass import metadata', () => {
+        reporter.maxChunkBytes = 200;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'first.js', suites: ['suite'] },
+          { name: 'test 2', file: 'second.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'first.js': 'first file body',
+            'second.js': 'second file body',
+          };
+        };
+        reporter.getPayloadSize = function (opts, tests, files) {
+          return Object.keys(files).length * 150 + tests.length * 10;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          const payload = JSON.parse(data);
+          requests.push(payload);
+
+          return {
+            statusCode: 200,
+            statusMessage: 'OK',
+            body: requests.length === 1 ? JSON.stringify({ import_id: 'import-123' }) : JSON.stringify({ ok: true }),
+          };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(2);
+          expect(requests[0]).to.include({
+            chunk_upload: true,
+            finish: false,
+            framework: 'mocha',
+          });
+          expect(requests[0]).to.not.have.property('import_id');
+          expect(requests[0].tests).to.have.length(1);
+          expect(Object.keys(requests[0].files)).to.deep.equal(['first.js']);
+
+          expect(requests[1]).to.include({
+            chunk_upload: true,
+            finish: true,
+            import_id: 'import-123',
+            framework: 'mocha',
+          });
+          expect(requests[1].tests).to.have.length(1);
+          expect(Object.keys(requests[1].files)).to.deep.equal(['second.js']);
+        });
+      });
+
+      it('should keep small uploads as a single request without chunk metadata', () => {
+        reporter.maxChunkBytes = 10000;
+
+        reporter.addTests([{ name: 'test 1', file: 'single.js', suites: ['suite'] }]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'single.js': 'single file body',
+          };
+        };
+        reporter.getPayloadSize = function () {
+          return 100;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          requests.push(JSON.parse(data));
+          return { statusCode: 200, statusMessage: 'OK', body: JSON.stringify({ ok: true }) };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(1);
+          expect(requests[0]).to.not.have.property('chunk_upload');
+          expect(requests[0]).to.not.have.property('finish');
+          expect(requests[0]).to.not.have.property('import_id');
+        });
+      });
+
+      it('should split upload when file count limit is exceeded', () => {
+        reporter.maxChunkBytes = 10000;
+        reporter.maxChunkFiles = 1;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'first.js', suites: ['suite'] },
+          { name: 'test 2', file: 'second.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'first.js': 'first file body',
+            'second.js': 'second file body',
+          };
+        };
+        reporter.getPayloadSize = function () {
+          return 100;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          requests.push(JSON.parse(data));
+          return {
+            statusCode: 200,
+            statusMessage: 'OK',
+            body:
+              requests.length === 1 ? JSON.stringify({ import_id: 'import-files-1' }) : JSON.stringify({ ok: true }),
+          };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(2);
+          expect(Object.keys(requests[0].files)).to.deep.equal(['first.js']);
+          expect(Object.keys(requests[1].files)).to.deep.equal(['second.js']);
+          expect(requests[1].import_id).to.equal('import-files-1');
+        });
+      });
+
+      it('should split tests from the same file when a file group exceeds payload size', () => {
+        reporter.maxChunkBytes = 240;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'shared.js', suites: ['suite'] },
+          { name: 'test 2', file: 'shared.js', suites: ['suite'] },
+          { name: 'test 3', file: 'shared.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'shared.js': 'shared file body that keeps payload above chunk threshold',
+          };
+        };
+        reporter.getPayloadSize = function (opts, tests) {
+          return tests.length * 120;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          requests.push(JSON.parse(data));
+          return {
+            statusCode: 200,
+            statusMessage: 'OK',
+            body: requests.length === 1 ? JSON.stringify({ import_id: 'import-456' }) : JSON.stringify({ ok: true }),
+          };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(2);
+          expect(requests[0].tests).to.have.length(2);
+          expect(requests[1].tests).to.have.length(1);
+          expect(Object.keys(requests[0].files)).to.deep.equal(['shared.js']);
+          expect(Object.keys(requests[1].files)).to.deep.equal(['shared.js']);
+          expect(requests[1].import_id).to.equal('import-456');
+        });
+      });
+
+      it('should split tests from the same file when test count limit is exceeded', () => {
+        reporter.maxChunkBytes = 10000;
+        reporter.maxChunkTests = 2;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'shared.js', suites: ['suite'] },
+          { name: 'test 2', file: 'shared.js', suites: ['suite'] },
+          { name: 'test 3', file: 'shared.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'shared.js': 'shared file body',
+          };
+        };
+        reporter.getPayloadSize = function () {
+          return 100;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          requests.push(JSON.parse(data));
+          return {
+            statusCode: 200,
+            statusMessage: 'OK',
+            body:
+              requests.length === 1
+                ? JSON.stringify({ import_id: 'import-shared-tests' })
+                : JSON.stringify({ ok: true }),
+          };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(2);
+          expect(requests[0].tests).to.have.length(2);
+          expect(requests[1].tests).to.have.length(1);
+          expect(Object.keys(requests[0].files)).to.deep.equal(['shared.js']);
+          expect(Object.keys(requests[1].files)).to.deep.equal(['shared.js']);
+        });
+      });
+
+      it('should split upload when test count limit is exceeded', () => {
+        reporter.maxChunkBytes = 10000;
+        reporter.maxChunkFiles = 10;
+        reporter.maxChunkTests = 2;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'first.js', suites: ['suite'] },
+          { name: 'test 2', file: 'second.js', suites: ['suite'] },
+          { name: 'test 3', file: 'third.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'first.js': 'first file body',
+            'second.js': 'second file body',
+            'third.js': 'third file body',
+          };
+        };
+        reporter.getPayloadSize = function () {
+          return 100;
+        };
+
+        const requests = [];
+        reporter.sendRequest = async data => {
+          requests.push(JSON.parse(data));
+          return {
+            statusCode: 200,
+            statusMessage: 'OK',
+            body:
+              requests.length === 1 ? JSON.stringify({ import_id: 'import-tests-1' }) : JSON.stringify({ ok: true }),
+          };
+        };
+
+        return reporter.send().then(() => {
+          expect(requests).to.have.length(2);
+          expect(requests[0].tests).to.have.length(2);
+          expect(requests[1].tests).to.have.length(1);
+          expect(requests[1].import_id).to.equal('import-tests-1');
+        });
+      });
+
+      it('should fail chunk upload when first response does not return import_id', () => {
+        reporter.maxChunkBytes = 200;
+
+        reporter.addTests([
+          { name: 'test 1', file: 'first.js', suites: ['suite'] },
+          { name: 'test 2', file: 'second.js', suites: ['suite'] },
+        ]);
+        reporter.attachFiles = function () {
+          this.files = {
+            'first.js': 'first file body',
+            'second.js': 'second file body',
+          };
+        };
+        reporter.getPayloadSize = function (opts, tests, files) {
+          return Object.keys(files).length * 150 + tests.length * 10;
+        };
+
+        reporter.sendRequest = async () => ({
+          statusCode: 200,
+          statusMessage: 'OK',
+          body: JSON.stringify({ ok: true }),
+        });
+
+        return reporter.send().then(
+          () => {
+            throw new Error('Expected send to fail when import_id is missing');
+          },
+          err => {
+            expect(String(err)).to.include('import_id');
+          },
+        );
+      });
+    });
+
     describe('labels functionality', () => {
       it('should not add labels property when TESTOMATIO_LABELS is not set', () => {
         delete process.env.TESTOMATIO_LABELS;


### PR DESCRIPTION
Implemented chunked uploads for large check-tests imports to avoid sending all parsed tests and files in a single request. The client now splits payloads by size, file count, and test count, then sends chunks sequentially using chunk_upload, finish, and import_id according to the backend contract. https://github.com/testomatio/check-tests/issues/260

maxChunkBytes = 1 * 1024 * 1024;
maxChunkFiles = 100;
maxChunkTests = 500;