### PR TITLE
Fix. Push "no-*" options is overriden by default values

### DIFF
--- a/bin/check.js
+++ b/bin/check.js
@@ -268,7 +268,7 @@ program
   )
   .action(async opts => {
     const globalOpts = program.opts();
-    const mergedOpts = { ...globalOpts, ...opts, updateIds: true };
+    const mergedOpts = { ...opts, ...globalOpts, updateIds: true };
     const files =
       opts.files && opts.files.length ? (opts.files.length === 1 ? opts.files[0] : opts.files) : '**/*.test.md';
     await mainAction('manual', files, mergedOpts);


### PR DESCRIPTION
Options like --no-empty passed as check-tests `push --no-empty` were incorrectly overridden by push subcommand's default values. This happened because Commander routes duplicate options to program.opts() (global), while the subcommand always had its own defaults (e.g. empty: true). With { ...globalOpts, ...opts }, subcommand defaults were winning over user-provided values.