### PR TITLE
fix: support Playwright alias annotations

### DIFF
--- a/example/playwright/custom-fixture-annotations.ts
+++ b/example/playwright/custom-fixture-annotations.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test';
+
+const testFixture = base.extend<{ someFixture: any }>({
+  someFixture: async ({}, use) => {
+    await use({ name: 'custom fixture name' });
+  },
+});
+
+testFixture('plain alias test', async ({ someFixture }) => {
+  console.warn(someFixture.name);
+});
+
+testFixture.skip('skipped alias test', async ({ someFixture }) => {
+  console.warn(someFixture.name);
+});
+
+testFixture.fixme('fixme alias test', async ({ someFixture }) => {
+  console.warn(someFixture.name);
+});
+
+testFixture.fail('failing alias test', async ({ someFixture }) => {
+  console.warn(someFixture.name);
+});
+
+testFixture.slow('slow alias test', async ({ someFixture }) => {
+  console.warn(someFixture.name);
+});
+
+testFixture.todo('todo alias test');
+
+testFixture.describe('alias suite', () => {
+  testFixture.fixme('fixme test inside alias suite', async ({ someFixture }) => {
+    console.warn(someFixture.name);
+  });
+});

--- a/src/lib/frameworks/playwright.js
+++ b/src/lib/frameworks/playwright.js
@@ -22,11 +22,35 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
   let beforeCode = '';
   let beforeEachCode = '';
   let afterCode = '';
+  const testNames = ['test', 'it', ...(opts?.testAlias || [])];
 
   function addSuite(path) {
     currentSuite = currentSuite.filter(s => s.loc.end.line > path.loc.start.line);
     path.tags = playwright.getTestProps({ parent: { expression: path } }).tags;
     currentSuite.push(path);
+  }
+
+  function getSuites(path) {
+    return currentSuite.filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path));
+  }
+
+  function getAnnotatedObjectName(path) {
+    if (!path.parent || !path.parent.object) return null;
+    return path.parent.object.name || path.parent.object.property?.name || path.parent.object.callee?.object?.name;
+  }
+
+  function addAnnotatedTest(path, skipped) {
+    if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
+
+    const suites = getSuites(path);
+    tests.push({
+      name: getStringValue(path.parentPath.container),
+      suites: suites.map(s => getStringValue(s)),
+      line: getLineNumber(path),
+      code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
+      file,
+      skipped: skipped || suites.some(s => s.skipped),
+    });
   }
 
   traverse(ast, {
@@ -90,101 +114,25 @@ module.exports = (ast, file = '', source = '', opts = {}) => {
         }
       }
 
-      if (path.isIdentifier({ name: 'skip' })) {
-        if (!path.parent || !path.parent.object) {
-          return;
-        }
-        const name =
-          path.parent.object.name || path.parent.object.property.name || path.parent.object.callee.object.name;
+      if (['skip', 'fixme', 'fail', 'slow'].includes(path.node.name)) {
+        const name = getAnnotatedObjectName(path);
+        if (!name) return;
 
-        if (name === 'test' || name === 'it') {
-          // test or it
-          if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
-
-          const testName = getStringValue(path.parentPath.container);
-          tests.push({
-            name: testName,
-            suites: currentSuite
-              .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
-              .map(s => getStringValue(s)),
-            line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
-            file,
-            skipped: true,
-          });
-        }
-
-        if (name === 'describe') {
-          // suite
+        if (testNames.includes(name)) {
+          addAnnotatedTest(path, path.node.name === 'skip' || path.node.name === 'fixme');
+        } else if ((path.node.name === 'skip' || path.node.name === 'fixme') && name === 'describe') {
           if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
           const suite = path.parentPath.container;
           suite.skipped = true;
           addSuite(suite);
         }
-
-        // todo: handle "context"
-      }
-
-      if (path.isIdentifier({ name: 'fixme' })) {
-        if (!path.parent || !path.parent.object) {
-          return;
-        }
-        const name =
-          path.parent.object.name || path.parent.object.property.name || path.parent.object.callee.object.name;
-
-        if (name === 'test' || name === 'it') {
-          // test or it
-          if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
-
-          const testName = getStringValue(path.parentPath.container);
-          tests.push({
-            name: testName,
-            suites: currentSuite
-              .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
-              .map(s => getStringValue(s)),
-            line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
-            file,
-            skipped: true,
-          });
-        }
-
-        if (name === 'describe') {
-          // suite
-          if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
-          const suite = path.parentPath.container;
-          suite.skipped = true;
-          addSuite(suite);
-        }
-
-        // todo: handle "context"
       }
 
       if (path.isIdentifier({ name: 'todo' })) {
-        if (!path.parent || !path.parent.object) {
-          return;
-        }
-        // todo tests => skipped tests
-        if (path.parent.object.name === 'test') {
-          // test
-          if (!hasStringOrTemplateArgument(path.parentPath.container)) return;
-
-          const testName = getStringValue(path.parentPath.container);
-          tests.push({
-            name: testName,
-            suites: currentSuite
-              .filter(s => getEndLineNumber({ container: s }) >= getLineNumber(path))
-              .map(s => getStringValue(s)),
-            line: getLineNumber(path),
-            code: getCode(source, getLineNumber(path), getEndLineNumber(path), isLineNumber),
-            file,
-            skipped: true,
-          });
-        }
+        if (testNames.includes(getAnnotatedObjectName(path))) addAnnotatedTest(path, true);
       }
 
-      const fixtureNames = [...['test', 'it'], ...(opts?.testAlias || [])];
-      for (const fiixtureName of fixtureNames || []) {
+      for (const fiixtureName of testNames || []) {
         if (path.isIdentifier({ name: fiixtureName })) {
           if (!hasStringOrTemplateArgument(path.parent)) return;
 

--- a/tests/playwright_test.js
+++ b/tests/playwright_test.js
@@ -505,6 +505,32 @@ test.describe.only('my test', () => {
     expect(tests.length).to.equal(1);
   });
 
+  it('should parse annotations on a custom test alias', () => {
+    source = fs.readFileSync('./example/playwright/custom-fixture-annotations.ts').toString();
+    ast = jsParser.parse(source, { sourceType: 'unambiguous', plugins: ['typescript'] });
+    const tests = playwrightParser(ast, '', source, { testAlias: ['testFixture'] });
+
+    const byName = name => tests.find(t => t.name === name);
+
+    expect(tests.length).to.equal(7);
+    expect(byName('plain alias test').skipped).to.be.false;
+    expect(byName('skipped alias test').skipped).to.be.true;
+    expect(byName('fixme alias test').skipped).to.be.true;
+    expect(byName('failing alias test').skipped).to.be.false;
+    expect(byName('slow alias test').skipped).to.be.false;
+    expect(byName('todo alias test').skipped).to.be.true;
+    expect(byName('fixme test inside alias suite').skipped).to.be.true;
+    expect(byName('fixme test inside alias suite').suites).to.deep.equal(['alias suite']);
+  });
+
+  it('should ignore custom alias annotations unless the alias is configured', () => {
+    source = fs.readFileSync('./example/playwright/custom-fixture-annotations.ts').toString();
+    ast = jsParser.parse(source, { sourceType: 'unambiguous', plugins: ['typescript'] });
+    const tests = playwrightParser(ast, '', source);
+
+    expect(tests.length).to.equal(0);
+  });
+
   it('should not crash when test is assigned to a variable or inside an array (regression for issue #1)', () => {
     const source = `
       // This works normally


### PR DESCRIPTION
## Summary
- support Playwright custom test aliases on annotated declarations: .skip, .fixme, .fail, .slow, and .todo
- reuse the existing alias list instead of changing analyzer glob behavior
- add a focused Playwright fixture covering configured and unconfigured aliases

## Why this is smaller than #271
This keeps the fix limited to the Playwright parser and tests. It does not add TypeScript glob expansion or change annotated test code capture behavior.

## Test plan
- ./node_modules/.bin/mocha tests/playwright_test.js
- ./node_modules/.bin/mocha tests/playwright_test.js tests/analyzer_test.js

Note: npm test still exits nonzero in tests/pull_test.js after the dirty-worktree git-check section, unrelated to this parser change.